### PR TITLE
Security: authenticate backend, lock down CORS/WS, sandbox session paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,126 @@
+# voice-claude
+
+A voice front-end for [Claude Code](https://claude.com/claude-code). A realtime
+voice agent (OpenAI / Azure OpenAI over WebRTC, or Google Gemini Live over
+WebSocket) acts as Claude's "mouth and ears": you speak, and it drives real
+Claude Code sessions on your machine — starting sessions in your projects,
+sending instructions, approving permission prompts, running slash commands, and
+narrating results back to you. A live terminal view streams the interactive
+Claude TUI to the browser (and your phone).
+
+- **Backend** (`backend/`): FastAPI. Mints short-lived voice-provider tokens
+  (provider keys stay server-side) and turns the voice agent's tool calls into
+  real actions against Claude Code via tmux. 
+- **Frontend** (`frontend/`): Next.js 16 / React 19. The browser UI, the voice
+  transports, and the live xterm terminal.
+
+> ⚠️ **This backend executes commands on your computer.** Read
+> [Security & access control](#security--access-control) before exposing it
+> beyond localhost.
+
+## Prerequisites
+
+- Python 3.12+ and Node 20+.
+- A Claude Code login (the CLI uses your existing subscription — no Anthropic API
+  key needed).
+- A realtime voice provider key: Azure OpenAI, OpenAI, or Google Gemini.
+
+## Setup
+
+```bash
+# 1. Backend deps
+cd backend
+python3 -m venv .venv
+.venv/bin/pip install -r requirements.txt
+
+# 2. Configure
+cp .env.example .env
+#    then edit .env — see "Configuration" below. At minimum set a voice provider
+#    key and ALLOWED_PROJECT_ROOTS.
+
+# 3. Frontend deps
+cd ../frontend
+npm ci
+```
+
+## Running
+
+### Localhost (simplest)
+
+```bash
+# terminal 1 — backend on http://localhost:8000
+cd backend && ./run.sh
+
+# terminal 2 — frontend on http://localhost:3000
+cd frontend && npm run dev
+```
+
+Open <http://localhost:3000>. On localhost the backend trusts loopback, so no
+auth token is needed.
+
+### LAN / phone (network mode)
+
+Binds the backend to `0.0.0.0` over TLS so your phone can reach it.
+
+```bash
+# requires VC_AUTH_TOKEN set in backend/.env (run-network.sh fails closed without it)
+cd backend && ./run-network.sh        # https://0.0.0.0:8000
+cd frontend && npm run dev:network     # https://0.0.0.0:3000
+```
+
+- Needs dev TLS certs at `frontend/.certs/dev-key.pem` and `dev-cert.pem`.
+- One-time per device: open `https://<host>:8000` and accept the self-signed
+  cert, or the `wss` terminal is silently blocked.
+- On each device, open the app once as
+  `https://<host>:3000/#vc_token=<your VC_AUTH_TOKEN>` — the browser stores the
+  token and strips it from the URL.
+
+## Configuration
+
+All backend config lives in `backend/.env` (copy from `.env.example`). Key
+settings:
+
+| Variable | Required | Purpose |
+|----------|----------|---------|
+| `ALLOWED_PROJECT_ROOTS` | **Yes** | Comma-separated dirs the agent may start sessions in. **The directory sandbox is mandatory** — if this is unset, `start_session` refuses to start (fail closed). Sessions cannot escape these roots. |
+| `VC_AUTH_TOKEN` | For network mode | Shared secret required on every sensitive request when set. **Required to expose the backend beyond localhost** (see below). |
+| `VOICE_PROVIDER` | Yes | `azure` \| `openai` \| `gemini` (can also be toggled in the UI). |
+| `AZURE_OPENAI_*` / `OPENAI_API_KEY` / `GEMINI_API_KEY` | Per provider | Provider credentials — stay server-side; the browser only ever gets a short-lived ephemeral token. |
+| `CLAUDE_MODEL` | No | `opus` (default) or `sonnet`. |
+| `VC_ALLOWED_ORIGINS` / `VC_ALLOWED_ORIGIN_REGEX` | No | Extra browser origins allowed cross-origin (localhost + private-LAN are allowed by default). |
+
+See `backend/.env.example` for the full annotated list.
+
+## Security & access control
+
+The backend turns voice/tool calls into real command execution, so access is
+gated by two independent layers:
+
+1. **Authentication — who can act.** Every sensitive endpoint and the live
+   terminal WebSocket require a shared secret `VC_AUTH_TOKEN`:
+   - **If `VC_AUTH_TOKEN` is set**, it is required from *every* caller (including
+     loopback, so the same-origin frontend proxy can't be used to relay an
+     unauthenticated remote request).
+   - **If it is unset**, only loopback (localhost) clients are allowed and all
+     remote requests are refused — so plain `run.sh` works with zero config,
+     while `run-network.sh` fails closed unless you set a token first.
+
+   The browser supplies the token once via
+   `https://<host>:3000/#vc_token=<token>` (persisted to `localStorage`); the
+   Next `/api/*` routes forward it; the WebSocket/SSE pass it as a query param.
+   Generate a token with:
+   ```bash
+   python3 -c "import secrets; print(secrets.token_urlsafe(32))"
+   ```
+
+2. **Directory sandbox — where they can act.** `ALLOWED_PROJECT_ROOTS` confines
+   every session's working directory. It is **mandatory**: with no roots
+   configured, `start_session` refuses rather than allowing a session anywhere on
+   the filesystem. Paths are realpath-resolved and containment-checked, so `..`,
+   symlinks, and absolute paths cannot escape the roots.
+
+Additional hardening: CORS is restricted to the trusted frontend origins (no
+wildcard) and the Origin allowlist is enforced in-app (not just via CORS response
+headers); the WebSocket handshake validates Origin + token before accepting; the
+auth token is redacted from access logs; and the interactive API docs
+(`/docs`, `/openapi.json`) are disabled.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -26,9 +26,36 @@ GEMINI_VOICE=Kore
 # no Anthropic API key needed. Opus is on-subscription until 2026-06-15.
 CLAUDE_MODEL=opus
 
-# Comma-separated default project dir(s) the voice agent may start sessions in.
-# Used to validate start_session paths.
+# Comma-separated project dir(s) the voice agent may start sessions in. REQUIRED:
+# the directory sandbox is mandatory — if this is unset, start_session refuses to
+# start (fail closed) rather than allowing a session anywhere on the filesystem.
+# Containment is enforced against these roots after realpath resolution, so
+# sessions can't escape them (no `..`, symlink, or absolute-path escapes).
 ALLOWED_PROJECT_ROOTS=/Users/nithiinkathiresan/Development
+
+# --- Access control ---------------------------------------------------------
+# The backend executes commands on this machine, so its endpoints + the live
+# terminal WebSocket are gated:
+#
+#   * VC_AUTH_TOKEN — shared secret required on every sensitive request. When
+#     UNSET, only loopback (localhost) clients are allowed, so plain `run.sh`
+#     works with zero config. To expose the backend to the LAN/phone
+#     (run-network.sh on 0.0.0.0), you MUST set this, or every remote request is
+#     refused. Generate one with e.g. `python -c "import secrets;
+#     print(secrets.token_urlsafe(32))"`. On the phone/laptop, open the app once
+#     as  https://<laptop-ip>:3000/#vc_token=THIS_VALUE  — the browser stores it
+#     and strips it from the URL. The token is required from everyone (incl.
+#     loopback) once set, so the Next proxy can't relay an unauthenticated
+#     remote request.
+# VC_AUTH_TOKEN=
+#
+#   * VC_ALLOWED_ORIGINS — extra exact browser origins allowed to call the
+#     backend cross-origin (the live terminal/debug stream are browser-direct).
+#     Localhost dev ports are always allowed; private-LAN origins on any port are
+#     allowed by default (override/disable with VC_ALLOWED_ORIGIN_REGEX, set it
+#     empty to disable). Comma-separated.
+# VC_ALLOWED_ORIGINS=
+# VC_ALLOWED_ORIGIN_REGEX=
 
 # On backend shutdown, kill interactive CLI sessions instead of leaving them
 # running. Default (unset): detach — sessions survive a restart and are

--- a/backend/config.py
+++ b/backend/config.py
@@ -8,6 +8,8 @@ regardless of which module imports config first.
 from __future__ import annotations
 
 import os
+import re
+import secrets
 
 try:  # dotenv is present in the venv; stay importable without it (e.g. in tests)
     from dotenv import load_dotenv
@@ -49,3 +51,85 @@ SESSION_STORE_DIR: str = os.path.abspath(os.path.expanduser(
 # sessions. Set VC_KILL_SESSIONS_ON_SHUTDOWN=1 to restore the old behavior where
 # stopping the backend kills every CLI session and removes its control dir.
 KILL_SESSIONS_ON_SHUTDOWN: bool = _env_bool("VC_KILL_SESSIONS_ON_SHUTDOWN", False)
+
+
+# --- Access control ---------------------------------------------------------
+#
+# The backend turns voice/tool calls into real command execution on this
+# machine, so its endpoints (and the live-terminal WebSocket) must not be open
+# to anyone who can reach the port. Two layers gate access:
+#
+#   1. A shared-secret token (VC_AUTH_TOKEN). When set, every sensitive endpoint
+#      and the terminal WebSocket require it (header `X-VC-Token` / `Authorization:
+#      Bearer` / `?token=`). When UNSET, only loopback (localhost) clients are
+#      allowed and any remote caller is refused — so plain `run.sh` on localhost
+#      needs zero config, while exposing the server to the LAN (run-network.sh)
+#      forces a token to be set first. The token is required even from loopback
+#      once configured, so the same-origin Next proxy can't be used to launder a
+#      remote attacker's request into a trusted loopback call.
+#
+#   2. A CORS / WebSocket-Origin allowlist (replaces the old `*`) so a malicious
+#      web page in the user's browser can't drive the backend cross-origin.
+AUTH_TOKEN: str = (os.getenv("VC_AUTH_TOKEN") or "").strip()
+
+
+def token_matches(provided: str | None) -> bool:
+    """Constant-time compare of a presented token against VC_AUTH_TOKEN.
+    Always False when no token is configured (callers fall back to loopback)."""
+    if not AUTH_TOKEN or not provided:
+        return False
+    return secrets.compare_digest(provided, AUTH_TOKEN)
+
+
+def _default_allowed_origins() -> list[str]:
+    """Exact frontend origins that may call the backend cross-origin (the live
+    terminal WS / debug stream are browser-direct). Localhost dev ports by
+    default; extend with VC_ALLOWED_ORIGINS (comma-separated)."""
+    base = [
+        "http://localhost:3000", "http://127.0.0.1:3000",
+        "https://localhost:3000", "https://127.0.0.1:3000",
+    ]
+    extra = [o.strip() for o in (os.getenv("VC_ALLOWED_ORIGINS") or "").split(",") if o.strip()]
+    # De-dupe, preserve order.
+    seen: set[str] = set()
+    out: list[str] = []
+    for o in [*base, *extra]:
+        if o not in seen:
+            seen.add(o)
+            out.append(o)
+    return out
+
+
+ALLOWED_ORIGINS: list[str] = _default_allowed_origins()
+
+# Private-LAN origins (any port) are allowed by default so the phone/laptop can
+# reach the backend over the LAN in network mode — mirrors next.config.mjs's
+# allowedDevOrigins. The token is still required there, so this regex is a
+# convenience for legitimate same-network devices, not the security boundary.
+# Override or disable with VC_ALLOWED_ORIGIN_REGEX (set it empty to disable).
+_DEFAULT_ORIGIN_REGEX = (
+    r"^https?://("
+    r"localhost|127\.0\.0\.1|\[::1\]|"
+    r"10\.\d{1,3}\.\d{1,3}\.\d{1,3}|"
+    r"192\.168\.\d{1,3}\.\d{1,3}|"
+    r"172\.(1[6-9]|2\d|3[01])\.\d{1,3}\.\d{1,3}"
+    r")(:\d{1,5})?$"
+)
+_origin_regex_raw = os.getenv("VC_ALLOWED_ORIGIN_REGEX")
+ALLOWED_ORIGIN_REGEX: str | None = (
+    _DEFAULT_ORIGIN_REGEX if _origin_regex_raw is None else (_origin_regex_raw.strip() or None)
+)
+_ORIGIN_RE = re.compile(ALLOWED_ORIGIN_REGEX) if ALLOWED_ORIGIN_REGEX else None
+
+
+def origin_allowed(origin: str | None) -> bool:
+    """Whether a browser Origin header is permitted (used for the WebSocket
+    handshake, where CORS middleware doesn't apply). An empty Origin (non-browser
+    clients) returns False here; the WS path treats a missing Origin separately."""
+    if not origin:
+        return False
+    if origin in ALLOWED_ORIGINS:
+        return True
+    # fullmatch (not match) so a trailing newline / extra suffix can't sneak past
+    # the `$` anchor.
+    return bool(_ORIGIN_RE and _ORIGIN_RE.fullmatch(origin))

--- a/backend/main.py
+++ b/backend/main.py
@@ -15,6 +15,7 @@ import json
 import logging
 import os
 import pty
+import re
 import signal
 import struct
 import termios
@@ -24,12 +25,13 @@ from typing import Any
 
 import httpx
 from dotenv import load_dotenv
-from fastapi import FastAPI, HTTPException, WebSocket, WebSocketDisconnect
+from fastapi import Depends, FastAPI, HTTPException, Request, WebSocket, WebSocketDisconnect
 from fastapi.concurrency import run_in_threadpool
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field
 
+import config
 import event_log
 from cost_log import COST_LOG_PATH, append_cost_event
 from session_manager import cli_pane_for, rehydrate_cli_sessions, shutdown_all
@@ -38,6 +40,25 @@ from tools import TOOL_DEFINITIONS, dispatch_tool
 load_dotenv()
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
 log = logging.getLogger("voice-claude")
+
+
+class _RedactTokenFilter(logging.Filter):
+    """Strip `token=...` from access-log lines. The shared secret rides the query
+    string on SSE (/debug/stream) and WebSocket (/sessions/.../terminal) connects
+    because those transports can't set headers — keep it out of access logs,
+    which are routinely shipped to stdout / aggregators / shown on screen-shares."""
+    _TOKEN_RE = re.compile(r"(token=)[^&\s\"']+")
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        if isinstance(record.args, tuple):
+            record.args = tuple(
+                self._TOKEN_RE.sub(r"\1[redacted]", a) if isinstance(a, str) else a
+                for a in record.args
+            )
+        return True
+
+
+logging.getLogger("uvicorn.access").addFilter(_RedactTokenFilter())
 
 # Default provider when the request doesn't specify one. "azure" | "openai" | "gemini"
 VOICE_PROVIDER = os.getenv("VOICE_PROVIDER", "azure").lower()
@@ -86,13 +107,84 @@ async def lifespan(_: FastAPI):
 DEBUG_POLLS = os.getenv("VC_DEBUG_POLLS", "0") == "1"
 
 
-app = FastAPI(title="Voice-Claude", lifespan=lifespan)
+# Interactive API docs are disabled: they'd disclose the full route/schema map
+# of a command-executing backend to anyone who can reach the port.
+app = FastAPI(title="Voice-Claude", lifespan=lifespan,
+              docs_url=None, redoc_url=None, openapi_url=None)
+# Origins restricted to the trusted frontend (localhost + private-LAN dev) instead
+# of "*": a malicious web page in the user's browser can no longer read responses
+# from — or make non-simple cross-origin calls to — the backend it can reach at
+# localhost. See config.ALLOWED_ORIGINS / VC_ALLOWED_ORIGINS.
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=config.ALLOWED_ORIGINS,
+    allow_origin_regex=config.ALLOWED_ORIGIN_REGEX,
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+# Hosts treated as "local" when no VC_AUTH_TOKEN is configured.
+_LOOPBACK_HOSTS = {"127.0.0.1", "::1", "localhost"}
+
+
+def _token_from(headers, query) -> str | None:
+    """Pull the shared-secret token from an Authorization: Bearer header, an
+    X-VC-Token header, or a ?token= query param (EventSource/WebSocket can't set
+    headers, so they use the query param)."""
+    auth = headers.get("authorization") or ""
+    if auth[:7].lower() == "bearer ":
+        return auth[7:].strip()
+    xt = headers.get("x-vc-token")
+    if xt:
+        return xt.strip()
+    return query.get("token")
+
+
+def _access_ok(client_host: str | None, token: str | None) -> tuple[bool, str]:
+    """Core access decision shared by HTTP and WebSocket paths.
+
+    - If VC_AUTH_TOKEN is configured: a matching token is required from everyone
+      (including loopback — so the same-origin Next proxy can't launder a remote
+      request into a trusted localhost call).
+    - Otherwise: only loopback clients are allowed; remote callers are refused
+      until a token is set.
+    """
+    if config.AUTH_TOKEN:
+        if config.token_matches(token):
+            return True, ""
+        return False, "missing or invalid auth token"
+    if client_host in _LOOPBACK_HOSTS:
+        return True, ""
+    return False, "remote access requires VC_AUTH_TOKEN to be set on the server"
+
+
+async def require_auth(request: Request) -> None:
+    """FastAPI dependency guarding every sensitive HTTP endpoint."""
+    # Origin allowlist, enforced in-app (not just via CORS response headers). A
+    # cross-origin POST is still delivered to the app even when CORS hides the
+    # response — and FastAPI parses a JSON body regardless of Content-Type — so a
+    # malicious page could otherwise fire a side-effecting "simple" request from
+    # a loopback-trusted browser. The same-origin Next proxy and native clients
+    # send no Origin; only real cross-origin browser requests carry one.
+    origin = request.headers.get("origin")
+    if origin and not config.origin_allowed(origin):
+        raise HTTPException(status_code=403, detail="origin not allowed")
+    token = _token_from(request.headers, request.query_params)
+    ok, reason = _access_ok(request.client.host if request.client else None, token)
+    if not ok:
+        raise HTTPException(status_code=401 if config.AUTH_TOKEN else 403, detail=reason)
+
+
+def _ws_access_ok(ws: WebSocket) -> tuple[bool, int]:
+    """Authorize a WebSocket handshake (CORS middleware does not apply to WS).
+    Returns (ok, close_code). Enforces the Origin allowlist for browser clients
+    and the same token/loopback rule as HTTP."""
+    origin = ws.headers.get("origin")
+    if origin and not config.origin_allowed(origin):
+        return False, 4403  # forbidden origin
+    token = _token_from(ws.headers, ws.query_params)
+    ok, _reason = _access_ok(ws.client.host if ws.client else None, token)
+    return (True, 0) if ok else (False, 4401)  # unauthorized
 
 
 class SessionRequest(BaseModel):
@@ -129,7 +221,7 @@ async def health() -> dict[str, str]:
     return {"status": "ok"}
 
 
-@app.get("/tools")
+@app.get("/tools", dependencies=[Depends(require_auth)])
 async def list_tools() -> dict[str, Any]:
     return {"tools": TOOL_DEFINITIONS}
 
@@ -201,7 +293,7 @@ def _mint_gemini_token(model: str) -> str:
     return token.name
 
 
-@app.post("/session")
+@app.post("/session", dependencies=[Depends(require_auth)])
 async def create_session(req: SessionRequest) -> dict[str, Any]:
     """Mint a realtime ephemeral token for the chosen provider. The provider key
     is read from the server environment and never reaches the browser; the browser
@@ -261,6 +353,13 @@ async def session_terminal(ws: WebSocket, handle: str) -> None:
     Bridges a PTY running `tmux attach-session` to the WebSocket: pane output ->
     ws bytes; ws text -> keystrokes; a {"__resize":{cols,rows}} message resizes.
     Closing the socket detaches the tmux client without killing the session."""
+    # Authorize the handshake BEFORE accepting: this socket injects raw keystrokes
+    # into the live Claude TUI, so an unauthenticated/cross-origin client must not
+    # reach the PTY. Rejecting before accept() denies the handshake outright.
+    ok, close_code = _ws_access_ok(ws)
+    if not ok:
+        await ws.close(code=close_code)
+        return
     await ws.accept()
     pane = cli_pane_for(handle)
     if not pane:
@@ -321,7 +420,7 @@ async def session_terminal(ws: WebSocket, handle: str) -> None:
             pass
 
 
-@app.post("/cost/log")
+@app.post("/cost/log", dependencies=[Depends(require_auth)])
 async def log_cost(req: CostLogRequest) -> dict[str, Any]:
     """Append one cost record to the JSONL log. The UI calls this on connection
     start, periodically while connected, and on disconnect."""
@@ -329,14 +428,14 @@ async def log_cost(req: CostLogRequest) -> dict[str, Any]:
     return {"ok": True, "path": str(COST_LOG_PATH)}
 
 
-@app.get("/debug/recent")
+@app.get("/debug/recent", dependencies=[Depends(require_auth)])
 async def debug_recent(limit: int = 500) -> dict[str, Any]:
     """Snapshot of the most recent pipeline events (ring buffer). Fallback for
     clients that can't hold an SSE connection."""
     return {"events": event_log.recent(limit)}
 
 
-@app.post("/debug/log")
+@app.post("/debug/log", dependencies=[Depends(require_auth)])
 async def debug_log(req: DebugLogRequest) -> dict[str, str]:
     """Ingest a browser-only event into the unified bus so it lands in the file
     and streams to every other connected panel alongside the backend events."""
@@ -345,7 +444,7 @@ async def debug_log(req: DebugLogRequest) -> dict[str, str]:
     return {"ok": "true"}
 
 
-@app.get("/debug/stream")
+@app.get("/debug/stream", dependencies=[Depends(require_auth)])
 async def debug_stream(limit: int = 200) -> StreamingResponse:
     """Server-Sent Events stream of the full pipeline. Replays the last `limit`
     buffered events on connect (so the panel isn't empty), then live-streams new
@@ -372,7 +471,7 @@ async def debug_stream(limit: int = 200) -> StreamingResponse:
     )
 
 
-@app.post("/tools/execute")
+@app.post("/tools/execute", dependencies=[Depends(require_auth)])
 async def execute_tool(req: ToolCallRequest) -> dict[str, Any]:
     """Run a function call dispatched from the voice session."""
     start = time.monotonic()

--- a/backend/run-network.sh
+++ b/backend/run-network.sh
@@ -4,8 +4,24 @@
 # frontend. Pair with `npm run dev:network` in ../frontend.
 # One-time per device: open https://<host>:8000 in the browser and accept the
 # self-signed cert, otherwise the wss terminal connection is silently blocked.
+#
+# SECURITY: this binds 0.0.0.0, so the backend is reachable from every device on
+# the LAN. You MUST set VC_AUTH_TOKEN in .env first (see .env.example) — without
+# it the backend refuses all non-loopback requests. Open the app on your devices
+# once as  https://<host>:3000/#vc_token=<the token>  to register the secret.
 set -euo pipefail
 cd "$(dirname "$0")"
+
+# Fail closed with a clear message: binding 0.0.0.0 without VC_AUTH_TOKEN leaves
+# the backend refusing every remote request (loopback-only), i.e. a non-functional
+# LAN app. Require the secret to be configured before exposing the port.
+if [ -z "${VC_AUTH_TOKEN:-}" ] && ! grep -qE '^[[:space:]]*VC_AUTH_TOKEN=[^[:space:]]+' .env 2>/dev/null; then
+  echo "ERROR: run-network.sh binds 0.0.0.0 but VC_AUTH_TOKEN is not set." >&2
+  echo "Set VC_AUTH_TOKEN in backend/.env (see .env.example) so remote/phone" >&2
+  echo "requests can authenticate; otherwise all non-loopback requests are refused." >&2
+  exit 1
+fi
+
 # --reload: hot-reload on backend code changes. With detach-on-shutdown the
 # reload preserves running CLI sessions (they're rehydrated on the restart).
 # --reload-dir . limits the watcher to backend/ so the session store under the

--- a/backend/session_manager.py
+++ b/backend/session_manager.py
@@ -211,7 +211,10 @@ def list_projects() -> dict:
 
 
 def _under_root(p: str, roots: list[str]) -> bool:
-    return (not roots) or any(p == r or p.startswith(r + os.sep) for r in roots)
+    # Fail closed: with no roots configured nothing is "under root". The directory
+    # sandbox is mandatory (see resolve_project_path), so this never returns True
+    # for an unconfigured server.
+    return bool(roots) and any(p == r or p.startswith(r + os.sep) for r in roots)
 
 
 def resolve_project_path(name: str) -> str:
@@ -220,9 +223,33 @@ def resolve_project_path(name: str) -> str:
     Handles: absolute paths, '~', a bare folder name matching a root or one of
     its subdirectories (case-insensitive), and an empty/vague value (defaults to
     the first allowed root). Raises ValueError listing real options on failure.
+
+    SECURITY: every candidate path — including the fuzzy-match branches — is
+    realpath-normalized and checked for containment under an allowed root via
+    `_contained()` before it can be returned, so inputs like ".." (which
+    `os.path.basename` collapses) cannot escape ALLOWED_PROJECT_ROOTS. Roots are
+    themselves realpath'd so symlinked roots compare correctly.
+
+    The directory sandbox is MANDATORY: if ALLOWED_PROJECT_ROOTS is not
+    configured this raises rather than letting a session start anywhere on the
+    filesystem (fail closed — defense in depth alongside the backend's auth).
     """
-    roots = _allowed_roots()
+    roots = [os.path.realpath(r) for r in _allowed_roots()]
+    if not roots:
+        raise ValueError(
+            "No project directories are configured, so I can't start a session. "
+            "Set ALLOWED_PROJECT_ROOTS in backend/.env (e.g. "
+            "ALLOWED_PROJECT_ROOTS=/Users/you/Development) and restart the backend."
+        )
     name = (name or "").strip()
+
+    def _contained(p: str) -> str | None:
+        """Realpath `p`; return it iff it's an existing directory under an
+        allowed root. Otherwise None."""
+        real = os.path.realpath(os.path.abspath(os.path.expanduser(p)))
+        if not os.path.isdir(real):
+            return None
+        return real if _under_root(real, roots) else None
 
     # Vague / empty -> default to the primary project root.
     if not name or name.lower() in {"anywhere", "any", "home", "default"}:
@@ -230,22 +257,24 @@ def resolve_project_path(name: str) -> str:
             return roots[0]
 
     # 1. Direct absolute / ~ path that exists and is allowed.
-    direct = os.path.abspath(os.path.expanduser(name))
-    if os.path.isdir(direct) and _under_root(direct, roots):
-        return direct
+    hit = _contained(name)
+    if hit:
+        return hit
 
     # 2. Fuzzy match against roots and their subdirectories (case-insensitive).
     low = name.lower().strip("/").split("/")[-1]
     for r in roots:
         if os.path.basename(r).lower() == low:
-            return r
-        cand = os.path.join(r, os.path.basename(name))
-        if os.path.isdir(cand):
-            return cand
+            return r  # the root itself is inherently contained
+        hit = _contained(os.path.join(r, os.path.basename(name)))
+        if hit:
+            return hit
         if os.path.isdir(r):
             for sub in os.listdir(r):
-                if sub.lower() == low and os.path.isdir(os.path.join(r, sub)):
-                    return os.path.join(r, sub)
+                if sub.lower() == low:
+                    hit = _contained(os.path.join(r, sub))
+                    if hit:
+                        return hit
 
     info = list_projects()
     names = [p["name"] for p in info["projects"]][:25]

--- a/frontend/app/api/cost/log/route.ts
+++ b/frontend/app/api/cost/log/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { forwardAuth } from "@/lib/proxyAuth";
 
 const BACKEND = process.env.BACKEND_URL || "http://localhost:8000";
 
@@ -8,7 +9,7 @@ export async function POST(req: NextRequest) {
   const body = await req.text();
   const resp = await fetch(`${BACKEND}/cost/log`, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: forwardAuth(req, { "Content-Type": "application/json" }),
     body,
   });
   const text = await resp.text();

--- a/frontend/app/api/session/route.ts
+++ b/frontend/app/api/session/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { forwardAuth } from "@/lib/proxyAuth";
 
 const BACKEND = process.env.BACKEND_URL || "http://localhost:8000";
 
@@ -6,7 +7,7 @@ export async function POST(req: NextRequest) {
   const body = await req.text();
   const resp = await fetch(`${BACKEND}/session`, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: forwardAuth(req, { "Content-Type": "application/json" }),
     body,
   });
   const text = await resp.text();

--- a/frontend/app/api/tools/execute/route.ts
+++ b/frontend/app/api/tools/execute/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { forwardAuth } from "@/lib/proxyAuth";
 
 const BACKEND = process.env.BACKEND_URL || "http://localhost:8000";
 
@@ -9,7 +10,7 @@ export async function POST(req: NextRequest) {
   const body = await req.text();
   const resp = await fetch(`${BACKEND}/tools/execute`, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: forwardAuth(req, { "Content-Type": "application/json" }),
     body,
   });
   const text = await resp.text();

--- a/frontend/app/api/tools/route.ts
+++ b/frontend/app/api/tools/route.ts
@@ -1,9 +1,13 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
+import { forwardAuth } from "@/lib/proxyAuth";
 
 const BACKEND = process.env.BACKEND_URL || "http://localhost:8000";
 
-export async function GET() {
-  const resp = await fetch(`${BACKEND}/tools`, { cache: "no-store" });
+export async function GET(req: NextRequest) {
+  const resp = await fetch(`${BACKEND}/tools`, {
+    cache: "no-store",
+    headers: forwardAuth(req),
+  });
   const text = await resp.text();
   return new NextResponse(text, {
     status: resp.status,

--- a/frontend/components/LiveTerminal.tsx
+++ b/frontend/components/LiveTerminal.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef } from "react";
 import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
+import { withAuthParam } from "@/lib/auth";
 
 // Streams the live interactive Claude TUI (CLI backend) by bridging the
 // backend's PTY-over-WebSocket terminal endpoint into an xterm.js instance.
@@ -43,7 +44,11 @@ export default function LiveTerminal({ handle }: { handle: string }) {
     // browser blocks it as mixed content. Plain http (localhost) uses ws.
     const host = window.location.hostname || "localhost";
     const proto = window.location.protocol === "https:" ? "wss" : "ws";
-    const ws = new WebSocket(`${proto}://${host}:8000/sessions/${handle}/terminal`);
+    // Append the shared-secret token (when configured) so the backend authorizes
+    // this keystroke-injecting socket; no-op on localhost (loopback-trusted).
+    const ws = new WebSocket(
+      withAuthParam(`${proto}://${host}:8000/sessions/${handle}/terminal`),
+    );
     ws.binaryType = "arraybuffer";
     wsRef.current = ws;
 

--- a/frontend/components/VoiceAgent.tsx
+++ b/frontend/components/VoiceAgent.tsx
@@ -5,6 +5,7 @@ import { RealtimeSession } from "@/lib/realtime";
 import { GeminiSession } from "@/lib/gemini";
 import { ClaudeBackend, RealtimeEvent, RealtimeOptions, VoiceProvider, VoiceSession, VoiceState, VoiceUsage } from "@/lib/voice";
 import { INSTRUCTIONS } from "@/lib/instructions";
+import { authHeaders, withAuthParam } from "@/lib/auth";
 import LiveTerminal from "./LiveTerminal";
 
 // One ordered list of bubbles + tool rows so the live "Conversation" panel renders
@@ -201,7 +202,7 @@ export default function VoiceAgent() {
     try {
       const r = await fetch("/api/tools/execute", {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: { "Content-Type": "application/json", ...authHeaders() },
         body: JSON.stringify({ name: "read_transcript", arguments: { session_id: handle } }),
       });
       const d = await r.json();
@@ -329,7 +330,7 @@ export default function VoiceAgent() {
       try {
         const r = await fetch("/api/tools/execute", {
           method: "POST",
-          headers: { "Content-Type": "application/json" },
+          headers: { "Content-Type": "application/json", ...authHeaders() },
           body: JSON.stringify({ name: "poll_session", arguments: { session_id: sessionId } }),
         });
         const data = await r.json();
@@ -372,7 +373,7 @@ export default function VoiceAgent() {
     try {
       fetch("/api/cost/log", {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: { "Content-Type": "application/json", ...authHeaders() },
         body: JSON.stringify({ record }),
         keepalive: true, // lets the request survive a tab-close on the disconnect path
       }).catch(() => undefined);
@@ -430,7 +431,7 @@ export default function VoiceAgent() {
     try {
       const r = await fetch("/api/tools/execute", {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: { "Content-Type": "application/json", ...authHeaders() },
         body: JSON.stringify({ name: "list_sessions", arguments: {} }),
       });
       const data = await r.json();
@@ -472,7 +473,7 @@ export default function VoiceAgent() {
     try {
       fetch(`${backendBase()}/debug/log`, {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: { "Content-Type": "application/json", ...authHeaders() },
         body: JSON.stringify({ source, dest, kind, summary, detail }),
         keepalive: true,
       }).catch(() => undefined);
@@ -484,7 +485,7 @@ export default function VoiceAgent() {
   // Subscribe to the unified pipeline stream. EventSource auto-reconnects; we
   // drop replayed events by monotonic seq so a reconnect doesn't duplicate.
   useEffect(() => {
-    const es = new EventSource(`${backendBase()}/debug/stream?limit=300`);
+    const es = new EventSource(withAuthParam(`${backendBase()}/debug/stream?limit=300`));
     esRef.current = es;
     es.onmessage = (e) => {
       try {
@@ -702,7 +703,7 @@ export default function VoiceAgent() {
     try {
       await fetch("/api/tools/execute", {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: { "Content-Type": "application/json", ...authHeaders() },
         body: JSON.stringify({ name: "set_mode", arguments: { session_id: handle, mode } }),
       });
     } finally {
@@ -727,7 +728,7 @@ export default function VoiceAgent() {
     try {
       await fetch("/api/tools/execute", {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: { "Content-Type": "application/json", ...authHeaders() },
         body: JSON.stringify({
           name: "rename_session",
           arguments: { session_id: handle, name },
@@ -745,7 +746,7 @@ export default function VoiceAgent() {
     setPending(null);
     await fetch("/api/tools/execute", {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", ...authHeaders() },
       body: JSON.stringify({
         name: "answer_prompt",
         arguments: { session_id: p.sessionId, choice },

--- a/frontend/lib/auth.ts
+++ b/frontend/lib/auth.ts
@@ -1,0 +1,70 @@
+// Client-side shared-secret token handling for remote (LAN / phone) access.
+//
+// On localhost the backend trusts loopback, so no token is needed and the app
+// works with zero config. When the backend is started with VC_AUTH_TOKEN set
+// (network mode, run-network.sh), every backend call must carry that token. The
+// user supplies it once via the URL — open `https://<laptop>:3000/#vc_token=SECRET`
+// on the phone/laptop — and we persist it to localStorage and strip it from the
+// address bar so it isn't left in history or shoulder-surfed.
+//
+// The token is NEVER baked into the JS bundle (unlike BACKEND_URL): it's only
+// ever supplied by the legitimate user at runtime, so loading the open frontend
+// yields a non-functional app without the secret.
+
+const KEY = "vc_auth_token";
+
+function captureFromUrl(): string | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const hash = new URLSearchParams((window.location.hash || "").replace(/^#/, ""));
+    const query = new URLSearchParams(window.location.search);
+    const token = hash.get("vc_token") || query.get("vc_token");
+    if (!token) return null;
+    window.localStorage.setItem(KEY, token);
+    // Remove the token from the visible URL (history, bookmarks, screen-share).
+    hash.delete("vc_token");
+    query.delete("vc_token");
+    const h = hash.toString();
+    const q = query.toString();
+    const url = window.location.pathname + (q ? `?${q}` : "") + (h ? `#${h}` : "");
+    window.history.replaceState(null, "", url);
+    return token;
+  } catch {
+    return null;
+  }
+}
+
+let captured = false;
+
+export function getAuthToken(): string | null {
+  if (typeof window === "undefined") return null;
+  // Capture a token passed in the URL exactly once per page load, then fall back
+  // to whatever is persisted. Re-read localStorage each call so a token set in
+  // another tab is picked up without a reload.
+  if (!captured) {
+    captured = true;
+    captureFromUrl();
+  }
+  try {
+    return window.localStorage.getItem(KEY);
+  } catch {
+    return null;
+  }
+}
+
+// Merge the auth token into a fetch headers object (for requests that can set
+// headers — i.e. fetch()). No-op when no token is configured (localhost).
+export function authHeaders(extra?: Record<string, string>): Record<string, string> {
+  const t = getAuthToken();
+  const base = { ...(extra || {}) };
+  if (t) base["X-VC-Token"] = t;
+  return base;
+}
+
+// Append the token as a ?token= query param, for transports that can't set
+// headers: EventSource (SSE) and WebSocket. No-op when no token is configured.
+export function withAuthParam(url: string): string {
+  const t = getAuthToken();
+  if (!t) return url;
+  return url + (url.includes("?") ? "&" : "?") + "token=" + encodeURIComponent(t);
+}

--- a/frontend/lib/gemini.ts
+++ b/frontend/lib/gemini.ts
@@ -26,6 +26,7 @@ import {
   emptyUsage,
   recomputeCost,
 } from "./voice";
+import { authHeaders } from "./auth";
 
 const INPUT_RATE = 16000;
 const OUTPUT_RATE = 24000;
@@ -160,7 +161,7 @@ export class GeminiSession implements VoiceSession {
     const emit = this.opts.onEvent;
     emit({ type: "status", status: "Minting token..." });
 
-    const toolsRes = await fetch("/api/tools");
+    const toolsRes = await fetch("/api/tools", { headers: authHeaders() });
     if (toolsRes.ok) this.tools = (await toolsRes.json()).tools || [];
 
     // Prepare audio graph before the socket opens so we can stream immediately.
@@ -175,7 +176,7 @@ export class GeminiSession implements VoiceSession {
     const emit = this.opts.onEvent;
     const sessionRes = await fetch("/api/session", {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", ...authHeaders() },
       body: JSON.stringify({
         provider: "gemini",
         model: this.opts.model,
@@ -527,7 +528,7 @@ export class GeminiSession implements VoiceSession {
     try {
       const r = await fetch("/api/tools/execute", {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: { "Content-Type": "application/json", ...authHeaders() },
         body: JSON.stringify({ name: fc.name, arguments: args }),
       });
       const out = await r.json();

--- a/frontend/lib/proxyAuth.ts
+++ b/frontend/lib/proxyAuth.ts
@@ -1,0 +1,21 @@
+import { NextRequest } from "next/server";
+
+// Forward the browser-presented shared-secret token to the backend.
+//
+// The Next /api/* routes run server-side and proxy to the FastAPI backend. They
+// hold NO secret of their own — they simply pass through whatever token the
+// browser presented (X-VC-Token / Authorization). The backend is the single
+// validator, so the open proxy can't be used to launder an unauthenticated
+// remote request into a trusted loopback call. No-op on localhost, where no
+// token is presented and the backend trusts loopback.
+export function forwardAuth(
+  req: NextRequest,
+  base: Record<string, string> = {},
+): Record<string, string> {
+  const headers = { ...base };
+  const xt = req.headers.get("x-vc-token");
+  if (xt) headers["X-VC-Token"] = xt;
+  const auth = req.headers.get("authorization");
+  if (auth) headers["Authorization"] = auth;
+  return headers;
+}

--- a/frontend/lib/realtime.ts
+++ b/frontend/lib/realtime.ts
@@ -18,6 +18,7 @@ import {
   emptyUsage,
   recomputeCost,
 } from "./voice";
+import { authHeaders } from "./auth";
 
 const CALLS_URL = "https://api.openai.com/v1/realtime/calls";
 
@@ -65,14 +66,14 @@ export class RealtimeSession implements VoiceSession {
     const [sessionRes, toolsRes] = await Promise.all([
       fetch("/api/session", {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: { "Content-Type": "application/json", ...authHeaders() },
         body: JSON.stringify({
           provider: this.opts.provider,
           model: this.opts.model,
           voice: this.opts.voice,
         }),
       }),
-      fetch("/api/tools"),
+      fetch("/api/tools", { headers: authHeaders() }),
     ]);
 
     if (!sessionRes.ok) throw new Error(`Session error: ${await sessionRes.text()}`);
@@ -394,7 +395,7 @@ export class RealtimeSession implements VoiceSession {
     try {
       const r = await fetch("/api/tools/execute", {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: { "Content-Type": "application/json", ...authHeaders() },
         body: JSON.stringify({ name, arguments: args }),
       });
       const data = await r.json();


### PR DESCRIPTION
Fixes the 5 findings from the security review of the voice-claude backend (which turns voice/tool calls into real command execution on the host). Each fix was verified locally and cross-checked by an adversarial review pass.

## Findings closed
| # | Severity | Issue | Fix |
|---|----------|-------|-----|
| 1 | High | `POST /tools/execute` unauthenticated → RCE (start_session `auto` + tell_claude) | `require_auth` on all state-changing endpoints |
| 2 | High | CORS `allow_origins=["*"]` | Restricted allowlist **+** in-app Origin check (stops cross-origin "simple" POSTs that CORS only hides) |
| 3 | High | Unauthenticated terminal WebSocket → keystroke injection into the Claude TUI | Authorize Origin + token/loopback **before** `accept()`/PTY fork |
| 4 | Med | `/debug/*` exposed transcripts/tool args unauthenticated | `require_auth` on all three (SSE token via `?token=`) |
| 5 | Med | `resolve_project_path` escaped `ALLOWED_PROJECT_ROOTS` (`..` → HOME) | realpath + containment on every branch; sandbox now **mandatory** (fail closed) |

## Access-control model
- **`VC_AUTH_TOKEN` shared secret.** Set → required from everyone (incl. loopback, so the same-origin proxy can't launder a remote request). Unset → loopback-only, remote refused. So **localhost (`run.sh`) needs zero config**; **`run-network.sh` fails closed** without a token.
- Browser supplies it once via `https://<host>:3000/#vc_token=…` → `localStorage` (`frontend/lib/auth.ts`); the Next `/api/*` routes forward it (`lib/proxyAuth.ts`); WS/SSE pass `?token=`.
- Hardening: CORS no longer wildcards; `/docs`·`/openapi.json` disabled; token redacted from access logs.

## Compatibility / action required
- **Localhost users:** no change — works with zero config.
- **Network/phone users:** set `VC_AUTH_TOKEN` in `backend/.env` and open the app once as `…/#vc_token=<token>` per device.
- **`ALLOWED_PROJECT_ROOTS` is now required** — `start_session` refuses if unset (you already have it set). See updated `README.md` / `.env.example`.

## Verification
Token enforcement (header/Bearer/query), loopback rule, CORS/Origin reflection, WS authorizer, cross-origin CSRF blocked, and path containment (`..`/`~`/`/etc`/symlink/sibling-prefix) all tested; unset-roots surfaces as a clean narratable error (not a 500). Frontend `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)