### PR TITLE
Homebrew packaging + README install docs (+ conversation scrollbar theming)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,53 @@ Claude TUI to the browser (and your phone).
   key needed).
 - A realtime voice provider key: Azure OpenAI, OpenAI, or Google Gemini.
 
-## Setup
+## Install with Homebrew (recommended)
+
+The quickest path on macOS (and Linuxbrew). The formula pulls in the system
+dependencies — `tmux`, Python 3.12, and Node — for you, builds the app, and puts
+a `voice-claude` command on your `PATH`:
+
+```bash
+brew tap nithiink/voice-claude
+brew install voice-claude
+```
+
+Then launch it:
+
+```bash
+voice-claude up
+```
+
+The first `up` runs a short **setup wizard**: it asks for your voice provider and
+API key and the folder(s) the agent may edit, auto-generates a `VC_AUTH_TOKEN`
+(for later network/phone use), and writes everything to
+`~/.config/voice-claude/.env` with `600` permissions. It then starts the backend
+and frontend and opens the app in your browser. Press Ctrl-C to stop both. That
+config file is the single source of truth — later runs never re-prompt.
+
+You still need **Claude Code installed and logged in** (see
+[Prerequisites](#prerequisites)) — it's the engine voice-claude drives. Homebrew
+can't install or log you into that for you.
+
+Other commands:
+
+```bash
+voice-claude config    # open ~/.config/voice-claude/.env to change settings
+voice-claude session   # start + attach a voice-ready Claude session in this dir
+```
+
+Update later with `brew upgrade voice-claude`. Your settings
+(`~/.config/voice-claude`) and runtime state (`~/.local/state/voice-claude`)
+live outside the install and survive upgrades and uninstall.
+
+For LAN/phone access, set up your config first with `voice-claude up`, then see
+[LAN / phone (network mode)](#lan--phone-network-mode) — that path uses the
+`VC_AUTH_TOKEN` the wizard already generated.
+
+## Setup (from source)
+
+Prefer to run from a clone — for development, or to hack on the code? Install the
+dependencies manually (you'll also need `tmux` on your `PATH`):
 
 ```bash
 # 1. Backend deps

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -143,9 +143,7 @@ body {
 /* Slim, theme-matched scrollbar shared by the secondary scroll areas so the
    native browser bar never clashes with the dark UI: transparent track, a
    rounded pill thumb in --line2 that warms to --mut on hover.
-   Firefox uses scrollbar-width/color; WebKit/Chromium uses ::-webkit-scrollbar.
-   The Conversation panel is deliberately excluded — it uses the OS-native
-   scrollbar (appears on scroll, auto-hides) plus a top fade instead. */
+   Firefox uses scrollbar-width/color; WebKit/Chromium uses ::-webkit-scrollbar. */
 .logscroll,
 .transcript,
 .tx-modal-body,
@@ -184,12 +182,28 @@ body {
 
 /* Conversation history (Option C): the panel always auto-scrolls to the latest
    message. A thick, prominent fade at the top softens the cut-off older messages
-   so it reads as "more above". The scrollbar is left to the OS — it appears
-   while scrolling and hides otherwise — so nothing persistent clutters the view. */
+   so it reads as "more above".
+   The scrollbar is theme-matched (no more clashing white OS bar) AND auto-hides:
+   the thumb is transparent at rest and only paints in --line2/--mut while the
+   user is scrolling. A JS scroll handler toggles the .scrolling class, then
+   removes it after a short idle, so the bar appears on scroll and fades out. */
 .conv-scroll.fade {
   -webkit-mask-image: linear-gradient(to bottom, transparent 0, rgba(0, 0, 0, 0.4) 48px, #000 104px);
   mask-image: linear-gradient(to bottom, transparent 0, rgba(0, 0, 0, 0.4) 48px, #000 104px);
 }
+.conv-scroll { scrollbar-width: thin; scrollbar-color: transparent transparent; transition: scrollbar-color 0.3s ease; }
+.conv-scroll.scrolling { scrollbar-color: var(--line2) transparent; }
+.conv-scroll::-webkit-scrollbar { width: 8px; height: 8px; }
+.conv-scroll::-webkit-scrollbar-track { background: transparent; }
+.conv-scroll::-webkit-scrollbar-thumb {
+  background: transparent;
+  border-radius: 999px;
+  border: 2px solid transparent;
+  background-clip: padding-box;
+  transition: background 0.3s ease;
+}
+.conv-scroll.scrolling::-webkit-scrollbar-thumb { background: var(--line2); background-clip: padding-box; }
+.conv-scroll.scrolling:hover::-webkit-scrollbar-thumb { background: var(--mut); background-clip: padding-box; }
 
 .empty { color: var(--dim); font-size: 14px; padding: 6px 2px; }
 

--- a/frontend/components/VoiceAgent.tsx
+++ b/frontend/components/VoiceAgent.tsx
@@ -347,9 +347,11 @@ export default function VoiceAgent() {
   const [fullscreen, setFullscreen] = useState(false);
   const [liveSession, setLiveSession] = useState<string | null>(null);
   const [liveFullscreen, setLiveFullscreen] = useState(false);
-  // Conversation panel always auto-scrolls to the latest message; the OS-native
-  // scrollbar (appears on scroll, hides otherwise) lets the user review history.
+  // Conversation panel always auto-scrolls to the latest message. The scrollbar
+  // is theme-matched and auto-hiding: a `.scrolling` class (toggled on scroll,
+  // cleared after a short idle) paints the thumb only while the user scrolls.
   const convScrollRef = useRef<HTMLDivElement | null>(null);
+  const convScrollHideRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   // Pipeline activity log (voice<->backend<->Claude) from the backend SSE stream.
   const [debugEvents, setDebugEvents] = useState<DebugEvent[]>([]);
   const [showDebug, setShowDebug] = useState(false);
@@ -1246,7 +1248,17 @@ export default function VoiceAgent() {
             Conversation <span className="ct">live</span>
           </h2>
           <div className="rule" />
-          <div ref={convScrollRef} className="scroll conv-scroll fade">
+          <div
+            ref={convScrollRef}
+            className="scroll conv-scroll fade"
+            onScroll={() => {
+              const el = convScrollRef.current;
+              if (!el) return;
+              el.classList.add("scrolling");
+              if (convScrollHideRef.current) clearTimeout(convScrollHideRef.current);
+              convScrollHideRef.current = setTimeout(() => el.classList.remove("scrolling"), 1000);
+            }}
+          >
             {timeline.length === 0 && (
               <div className="empty">Assistant replies and Claude actions show here.</div>
             )}

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -1,0 +1,47 @@
+# Packaging — Homebrew distribution
+
+Staged Homebrew formula and release tooling. **Not live yet:** a formula installs
+by fetching the source tarball over anonymous HTTPS, which 404s while the repo is
+private. Publish only after the repo is public and a release tag exists.
+
+## Files
+
+- **`voice-claude.rb`** — the formula (source-of-truth draft). Declares the
+  `node` / `python@3.12` / `tmux` dependencies, builds the Python venv and the
+  Next.js production bundle at install time, and installs a `voice-claude`
+  launcher on `PATH`. The launcher redirects the backend's runtime writes
+  (session store, cost/debug logs) into `~/.local/state/voice-claude` so nothing
+  is written into the read-only Cellar.
+- **`release.sh`** — tags a release, computes the tarball `sha256`, and stamps
+  `url` + `sha256` into `voice-claude.rb`.
+
+## Going-live sequence (after the repo is public)
+
+1. **Scrub first** (separate from packaging): purge committed logs
+   (`cost-log.jsonl`, `debug-log.jsonl`) from history, confirm no secrets in
+   history, tighten `.gitignore`.
+2. **Make the repo public.**
+3. **Cut a release + stamp the formula:**
+   ```bash
+   packaging/release.sh v0.1.0
+   ```
+4. **Create the tap repo** `github.com/nithiink/homebrew-voice-claude` (public),
+   copy the stamped `voice-claude.rb` to `Formula/voice-claude.rb`, and push.
+5. **Users install:**
+   ```bash
+   brew tap nithiink/voice-claude
+   brew install voice-claude
+   voice-claude up
+   ```
+
+## Updating later
+
+Bump the version, re-run `packaging/release.sh vX.Y.Z`, and copy the stamped
+formula into the tap. Users upgrade with `brew upgrade voice-claude`.
+
+## Prerequisites the formula can't remove
+
+`brew install` handles the system dependencies, but every user still needs
+**Claude Code installed and logged in** and a **voice-provider key** — the
+formula's `caveats` block tells them so, and the first `voice-claude up` runs the
+setup wizard.

--- a/packaging/release.sh
+++ b/packaging/release.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Cut a voice-claude release and stamp the Homebrew formula.
+#
+#   packaging/release.sh v0.1.0
+#
+# What it does:
+#   1. Verifies a clean working tree.
+#   2. Creates + pushes an annotated git tag (skips if it already exists).
+#   3. Downloads the exact tarball GitHub will serve to `brew` and computes its
+#      sha256.
+#   4. Stamps `url` and `sha256` into packaging/voice-claude.rb.
+#
+# After it runs, copy packaging/voice-claude.rb into the tap repo
+# (github.com/nithiink/homebrew-voice-claude -> Formula/voice-claude.rb) and push.
+#
+# Note: the repo must be PUBLIC for the tarball fetch (and ultimately `brew
+# install`) to work — a private repo returns 404 to anonymous HTTPS.
+set -euo pipefail
+
+VERSION="${1:-}"
+[ -n "$VERSION" ] || { echo "usage: $0 vX.Y.Z" >&2; exit 2; }
+case "$VERSION" in
+  v[0-9]*) ;;
+  *) echo "version must look like v0.1.0 (got '$VERSION')" >&2; exit 2 ;;
+esac
+
+REPO_SLUG="${VOICE_CLAUDE_REPO:-nithiink/voice-claude}"
+OWNER="${REPO_SLUG%%/*}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FORMULA="$ROOT/packaging/voice-claude.rb"
+[ -f "$FORMULA" ] || { echo "formula not found at $FORMULA" >&2; exit 1; }
+
+# 1. clean tree
+if [ -n "$(git -C "$ROOT" status --porcelain)" ]; then
+  echo "working tree is not clean — commit or stash first" >&2; exit 1
+fi
+branch="$(git -C "$ROOT" branch --show-current)"
+[ "$branch" = "main" ] || echo "warning: releasing from '$branch', not main" >&2
+
+# 2. tag + push (idempotent)
+if git -C "$ROOT" rev-parse -q --verify "refs/tags/$VERSION" >/dev/null; then
+  echo "tag $VERSION already exists — reusing it" >&2
+else
+  git -C "$ROOT" tag -a "$VERSION" -m "voice-claude $VERSION"
+  git -C "$ROOT" push origin "$VERSION"
+fi
+
+# 3. fetch the release tarball and hash it
+URL="https://github.com/$REPO_SLUG/archive/refs/tags/$VERSION.tar.gz"
+echo "fetching $URL …" >&2
+tarball="$(mktemp)"
+trap 'rm -f "$tarball"' EXIT
+if ! curl -fsSL "$URL" -o "$tarball"; then
+  echo "could not download $URL — is the repo public and the tag pushed?" >&2
+  exit 1
+fi
+if command -v sha256sum >/dev/null 2>&1; then
+  SHA="$(sha256sum "$tarball" | awk '{print $1}')"
+else
+  SHA="$(shasum -a 256 "$tarball" | awk '{print $1}')"
+fi
+echo "sha256 = $SHA" >&2
+
+# 4. stamp url + sha256 into the formula (| delimiter avoids escaping the URL).
+#    Both patterns replace to end-of-line so any trailing placeholder comment is
+#    dropped on stamp.
+tmp="$(mktemp)"
+sed -E \
+  -e "s|^([[:space:]]*url ).*|\1\"$URL\"|" \
+  -e "s|^([[:space:]]*sha256 ).*|\1\"$SHA\"|" \
+  "$FORMULA" > "$tmp"
+mv "$tmp" "$FORMULA"
+echo "stamped $FORMULA" >&2
+
+cat >&2 <<EOF
+
+Done.
+  1. Review:  git -C "$ROOT" diff -- packaging/voice-claude.rb
+  2. Copy packaging/voice-claude.rb to the tap repo
+     (github.com/$OWNER/homebrew-voice-claude) at Formula/voice-claude.rb,
+     commit, and push.
+  3. Users then install with:
+       brew tap $OWNER/voice-claude
+       brew install voice-claude
+EOF

--- a/packaging/voice-claude.rb
+++ b/packaging/voice-claude.rb
@@ -1,0 +1,79 @@
+# voice-claude Homebrew formula (DRAFT — staged for when the repo goes public).
+#
+# This is the source-of-truth copy. To publish: run packaging/release.sh vX.Y.Z
+# (it tags a release, computes the sha256, and stamps `url`/`sha256` below), then
+# copy this file into the tap repo (github.com/nithiink/homebrew-voice-claude) at
+# Formula/voice-claude.rb and push. See packaging/README.md.
+#
+# It will NOT install while the repo is private — `brew` fetches the source
+# tarball over anonymous HTTPS, which 404s on a private repo. Publish only after
+# the repo is public and a release tag exists.
+class VoiceClaude < Formula
+  desc "Voice front-end for Claude Code — talk to drive real Claude Code sessions"
+  homepage "https://github.com/nithiink/voice-claude"
+  url "https://github.com/nithiink/voice-claude/archive/refs/tags/v0.1.0.tar.gz"
+  sha256 "0000000000000000000000000000000000000000000000000000000000000000" # PLACEHOLDER — release.sh stamps this
+  license "MIT"
+
+  depends_on "node"
+  depends_on "python@3.12"
+  depends_on "tmux"
+
+  def install
+    # Full source tree -> Cellar/voice-claude/<ver>/libexec
+    libexec.install Dir["*"]
+
+    # Python backend virtualenv (built once, here, not at runtime)
+    python = Formula["python@3.12"].opt_bin/"python3.12"
+    system python, "-m", "venv", libexec/"backend/.venv"
+    system libexec/"backend/.venv/bin/pip", "install", "--no-input",
+           "-r", libexec/"backend/requirements.txt"
+
+    # Frontend production build (so the launcher runs `next start`, no compile-on-launch)
+    cd libexec/"frontend" do
+      system "npm", "ci"
+      system "npm", "run", "build"
+    end
+
+    # Launcher wrapper on PATH. It (1) pins the install tree via VOICE_CLAUDE_ROOT
+    # and (2) redirects the backend's runtime writes (session store + logs) into
+    # the user's state dir, since the Cellar must be treated as read-only. Each
+    # `:=` respects a value the user already set, so overrides still win.
+    (bin/"voice-claude").write <<~SH
+      #!/bin/bash
+      export VOICE_CLAUDE_ROOT="#{libexec}"
+      state="${XDG_STATE_HOME:-$HOME/.local/state}/voice-claude"
+      mkdir -p "$state/tmux"
+      : "${VC_SESSION_STORE:=$state/tmux}";             export VC_SESSION_STORE
+      : "${VC_COST_LOG_PATH:=$state/cost-log.jsonl}";   export VC_COST_LOG_PATH
+      : "${VC_DEBUG_LOG_PATH:=$state/debug-log.jsonl}"; export VC_DEBUG_LOG_PATH
+      exec "#{libexec}/bin/voice-claude" "$@"
+    SH
+    chmod 0755, bin/"voice-claude"
+  end
+
+  def caveats
+    <<~EOS
+      voice-claude is a front-end for Claude Code — it needs Claude Code
+      installed and logged in (uses your existing subscription, no API key):
+        https://claude.com/claude-code   (run `claude` once and sign in)
+
+      First launch runs a short setup wizard (voice provider, key, allowed
+      folders) and writes ~/.config/voice-claude/.env. Then:
+
+        voice-claude up        # start the app and open it in your browser
+        voice-claude config    # edit settings later
+
+      Config (~/.config/voice-claude) and runtime state
+      (~/.local/state/voice-claude) live outside the Cellar and survive
+      upgrades and uninstall.
+    EOS
+  end
+
+  test do
+    # Unknown subcommand prints usage and exits 2 — exercises the launcher
+    # without needing Claude Code, a voice key, or any prompt.
+    output = shell_output("#{bin}/voice-claude bogus-subcommand 2>&1", 2)
+    assert_match "usage: voice-claude", output
+  end
+end


### PR DESCRIPTION
## Summary

Stages Homebrew distribution for voice-claude and documents it, plus an unrelated UI tweak that rode along on this branch.

### Homebrew packaging — `packaging/` (draft, pre-public)
Not live until the repo is public (a formula fetches the source tarball over anonymous HTTPS, which 404s while private).

- **`voice-claude.rb`** — formula declaring `node`/`python@3.12`/`tmux`; builds the Python venv and Next.js production bundle at install time; installs a `voice-claude` launcher on `PATH` that pins the install tree and **redirects the backend's runtime writes** (`VC_SESSION_STORE`/`VC_COST_LOG_PATH`/`VC_DEBUG_LOG_PATH`) into `~/.local/state/voice-claude` so nothing writes into the read-only Cellar.
- **`release.sh`** — tags a release, downloads the GitHub tarball, computes its `sha256`, and stamps `url`+`sha256` into the formula.
- **`README.md`** — the going-live sequence and tap setup.

### README install docs
Adds an **"Install with Homebrew (recommended)"** section (tap/install, the `voice-claude up` first-run wizard, `config`/`session`, `brew upgrade`) and reframes the existing manual steps as **"Setup (from source)"**.

### Conversation scrollbar theming (`bb4a328`, authored separately)
Themes the conversation panel scrollbar so the native white OS bar no longer clashes with the dark UI (`frontend/app/globals.css`, `frontend/components/VoiceAgent.tsx`). Unrelated to packaging, but committed onto this branch and kept here intentionally.

## Testing
- `ruby -c` on the formula and `bash -n` on `release.sh` — clean.
- `brew style` — only non-applicable Sorbet/frozen-string conventions.
- Stamping dry-run verified `url`/`sha256` rewrite and placeholder removal.
- README heading structure and anchor links verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)