### PR TITLE
Guard against old Python: launcher check + docs

### DIFF
--- a/FRIEND_SETUP.md
+++ b/FRIEND_SETUP.md
@@ -62,6 +62,17 @@ will be rejected — that's intentional.)
 On localhost the mic works without certs and **no auth token is needed**.
 
 ```bash
+# 0. Check your Python — must print 3.12 or newer!
+python3 --version
+```
+
+If it's older, `pip install` below fails with a **misleading**
+`No matching distribution found for claude-agent-sdk==…`. Fix: on macOS,
+`brew install python@3.12` and use `python3.12 -m venv .venv` in step 1; on
+Windows/WSL, install a current Ubuntu (`wsl --install -d Ubuntu-24.04` in
+PowerShell — its default `python3` is 3.12) and redo the setup inside it.
+
+```bash
 # 1. Backend deps
 cd backend
 python3 -m venv .venv
@@ -119,6 +130,11 @@ exec $SHELL
 nvm install 20
 ```
 
+Then check `python3 --version` — the backend needs **3.12+**. A fresh
+`wsl --install` gives you Ubuntu 24.04, which ships 3.12. If you're on an older
+WSL Ubuntu (20.04 = 3.8, 22.04 = 3.10), install a current one from PowerShell
+(`wsl --install -d Ubuntu-24.04`) and do everything inside that instead.
+
 **3. Install Claude Code *inside WSL* and log in** — it must live on the Linux
 side. Install per <https://claude.com/claude-code>, then run `claude` once and
 sign in.
@@ -163,6 +179,11 @@ first testing.
 
 ## Troubleshooting
 
+- `No matching distribution found for claude-agent-sdk==…` during
+  `pip install` → your `python3` is too old (needs 3.12+; Ubuntu 20.04's
+  default is 3.8). macOS: `brew install python@3.12`, then recreate the venv
+  with `python3.12 -m venv .venv`. WSL: install Ubuntu 24.04
+  (`wsl --install -d Ubuntu-24.04`) and redo the setup there.
 - `git@github-voiceclaude: Permission denied (publickey)` → your key isn't added
   yet (ping me) or the `~/.ssh/config` alias above is missing.
 - `start_session refuses` / "no allowed roots" → `ALLOWED_PROJECT_ROOTS` isn't

--- a/README.md
+++ b/README.md
@@ -75,6 +75,12 @@ For LAN/phone access, set up your config first with `voice-claude up`, then see
 Prefer to run from a clone — for development, or to hack on the code? Install the
 dependencies manually (you'll also need `tmux` on your `PATH`):
 
+> **Check your Python first:** `python3 --version` must print **3.12+**. With an
+> older default (Ubuntu 20.04 ships 3.8) pip fails with the misleading error
+> `No matching distribution found for claude-agent-sdk==…`. If yours is older:
+> on macOS `brew install python@3.12` and substitute `python3.12` for `python3`
+> below; on Ubuntu upgrade to **24.04**, whose default `python3` is 3.12.
+
 ```bash
 # 1. Backend deps
 cd backend
@@ -152,6 +158,15 @@ sudo apt update && sudo apt install -y tmux git python3 python3-venv curl
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
 exec $SHELL
 nvm install 20
+```
+
+Then check `python3 --version` — it must be **3.12+**. **Ubuntu 24.04** (what a
+fresh `wsl --install` gives you) ships 3.12; if you're on an older WSL distro
+(20.04 ships 3.8, 22.04 ships 3.10), install a current one from PowerShell and
+redo these steps inside it:
+
+```powershell
+wsl --install -d Ubuntu-24.04
 ```
 
 **3. Install Claude Code *inside WSL* and log in.** It must live on the Linux

--- a/bin/voice-claude
+++ b/bin/voice-claude
@@ -180,10 +180,32 @@ ensure_env() { [ -f "$ENV_FILE" ] || run_wizard; }
 
 # --- one-time dependency bootstrap (no-op once set up) ----------------------
 
+# The backend needs Python 3.12+. With an older default python3 (Ubuntu 20.04
+# ships 3.8) pip fails with a misleading "No matching distribution found for
+# claude-agent-sdk==…", so pick a suitable interpreter and fail clearly instead.
+find_python() {
+  local c
+  for c in python3 python3.13 python3.12; do
+    if command -v "$c" >/dev/null 2>&1 && \
+       "$c" -c 'import sys; sys.exit(0 if sys.version_info >= (3, 12) else 1)' 2>/dev/null; then
+      command -v "$c"; return 0
+    fi
+  done
+  return 1
+}
+
 bootstrap() {
   if [ ! -x "$APP_ROOT/backend/.venv/bin/python" ]; then
+    local py
+    if ! py="$(find_python)"; then
+      err "voice-claude: Python 3.12+ is required (found: $(python3 --version 2>&1 || echo 'no python3'))."
+      err "  macOS:  brew install python@3.12"
+      err "  Ubuntu: upgrade to 24.04, whose default python3 is 3.12"
+      err "          (WSL: run  wsl --install -d Ubuntu-24.04  in PowerShell)"
+      exit 1
+    fi
     err "Setting up the Python backend (first run)…"
-    python3 -m venv "$APP_ROOT/backend/.venv"
+    "$py" -m venv "$APP_ROOT/backend/.venv"
     "$APP_ROOT/backend/.venv/bin/pip" install -q -r "$APP_ROOT/backend/requirements.txt"
   fi
   if [ ! -d "$APP_ROOT/frontend/node_modules" ]; then


### PR DESCRIPTION
## Summary

A beta tester on Ubuntu 20.04 (default `python3` = 3.8) hit pip's misleading `No matching distribution found for claude-agent-sdk==0.2.87` during Phase 4 of FRIEND_SETUP. The version exists on PyPI (verified) — the SDK requires Python ≥ 3.10 and the project requires 3.12+, so pip filtered out every release and produced an error that reads like a missing package.

This closes that trap in three places:

### `bin/voice-claude`
`bootstrap()` now resolves an interpreter via `find_python()` — tries `python3`, `python3.13`, `python3.12` and takes the first that is ≥ 3.12 — and uses it for the venv. If none qualifies, it fails with a clear, actionable message (brew on macOS / Ubuntu 24.04 on Linux+WSL) instead of letting pip mislead the user.

### `README.md`
- **Setup (from source):** a "check your Python first" callout explaining the misleading error and the fix.
- **Windows (WSL2):** check `python3 --version` after the toolchain step; on older WSL distros install Ubuntu 24.04 (`wsl --install -d Ubuntu-24.04`).

### `FRIEND_SETUP.md`
- Step **0** in Phase 4: `python3 --version` must print 3.12+, with the fix inline.
- The same Ubuntu 24.04 note in the WSL toolchain step.
- A troubleshooting entry mapping the exact pip error to its real cause.

## Decision: recommend Ubuntu 24.04, not deadsnakes
Per Nithiin's call, the docs recommend upgrading to a current Ubuntu instead of adding the deadsnakes PPA — avoids instructing testers to add a third-party root-level package source, and 20.04 is past standard support anyway.

## Testing
- `bash -n bin/voice-claude` clean.
- `find_python()` tested both ways: with a simulated Python 3.8 environment the guard trips with the clear error; on a real ≥3.12 machine it resolves the right interpreter (3.12.4 via pyenv).
- `grep -ri deadsnakes` across the three files: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)