### PR TITLE
Wizard: live masked input — bullets render at paste time

### DIFF
--- a/bin/yapcode
+++ b/bin/yapcode
@@ -52,12 +52,30 @@ read_secret() { # read_secret "Prompt" -> echoes secret, never echoes keystrokes
 }
 
 # Like read_secret, but a plain Enter (empty input) returns "" instead of
-# re-prompting — used for the two optional voice-provider keys. Whitespace is
-# trimmed from both ends (spaces/tabs/CR/LF) because pasted keys often carry a
-# trailing newline. EOF still aborts so we never write a half-baked config.
+# re-prompting — used for the two optional voice-provider keys. Reads ONE
+# character at a time (-rsn1) so we can echo a live `•` mask as each keystroke
+# arrives: a paste instantly renders one bullet per pasted character, giving
+# visual feedback AT PASTE TIME rather than only after Enter. Backspace/DEL
+# erases the last bullet. Enter (with -n1, c is "") finishes; an empty buffer
+# still returns "". Whitespace is trimmed from both ends (spaces/tabs/CR/LF)
+# because pasted keys often carry a trailing newline (which also naturally
+# terminates the read, equivalent to pressing Enter). EOF before any Enter
+# aborts so we never write a half-baked config.
 read_secret_optional() { # read_secret_optional "Prompt" -> echoes (possibly empty) secret
-  local q="$1" s=""
-  if ! read -rsp "$q: " s; then # EOF (Ctrl-D / closed pipe)
+  local q="$1" s="" c="" got_enter=0
+  printf '%s: ' "$q" >&2
+  # With -n1, `read` returns success on Enter (delivering c="") and on any
+  # normal key; it returns non-zero only at EOF. So we loop, and the moment we
+  # see an empty c from a *successful* read we know it was Enter and stop.
+  while IFS= read -rsn1 c; do
+    if [ -z "$c" ]; then got_enter=1; break; fi # Enter
+    case "$c" in
+      $'\x7f'|$'\b') # Backspace / DEL: drop last char, erase one bullet
+        if [ -n "$s" ]; then s="${s%?}"; printf '\b \b' >&2; fi ;;
+      *) s="$s$c"; printf '•' >&2 ;;
+    esac
+  done
+  if [ "$got_enter" -eq 0 ]; then # loop ended via read failure = EOF, never Enter
     printf '\n' >&2; err "yapcode: no input — aborting setup"; exit 1
   fi
   printf '\n' >&2


### PR DESCRIPTION
## What changed

`read_secret_optional()` in `bin/yapcode` (the two optional voice-provider keys in the first-run wizard) previously read with `read -rsp` — fully silent until Enter, with the masked receipt only printed afterward. Users wanted visual feedback **at paste time**, not after Enter.

This rewrites it to read character-by-character with live masking:

- Prompt printed to stderr, then `IFS= read -rsn1 c` in a loop.
- **Enter** (with `-n1`, a successful read delivers `c=""`) → done.
- **Backspace/DEL** (`$'\x7f'` / `$'\b'`) → drop last char from the buffer and erase one bullet on screen (`printf '\b \b'`).
- **Any other char** → append to buffer, print one `•` to stderr. A paste instantly renders one bullet per pasted character — that's the feature.
- **EOF** before any Enter → newline + `yapcode: no input — aborting setup`, exit 1 (preserves the existing abort so a closed pipe never writes a half-baked config).
- **Empty buffer + Enter** still returns `""` (the `[Enter to skip]` behavior is preserved).
- Result is still `trim`med (handles a pasted trailing newline / `\r`).

The existing `secret_receipt` call sites in `run_wizard` are unchanged: the post-Enter receipt still confirms **what** was captured (masked first4…last4 + length); the live bullets confirm **that** it landed. No other code touched (`read_secret` left as-is).

## Verification

- `bash -n bin/yapcode` → clean.
- Wizard driven via `YAPCODE_CONFIG_DIR=$(mktemp -d) EDITOR=true ./bin/yapcode config` with **fake keys only**, isolated config dir:
  - Bullets render in stderr; count == key length (20 + 14 = 34 bullets for the two keys).
  - Stored `.env` values correct and trimmed (`GEMINI_API_KEY`, `OPENAI_API_KEY`), `VOICE_PROVIDER` derived to `gemini`.
  - **Skip** (bare newline) → both keys empty, "skipped" shown, 0 bullets, provider falls back to `openai`.
  - **Backspace**: `printf 'abc\x7f\x7fd\n'` → stored value `ad`, receipt shows `(2 chars)` (length only, ≤12).
  - **EOF** (`</dev/null`) → exit 1, abort message, no `.env` written.
  - No full key in stdout/stderr; real `~/.config/yapcode` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)