### PR TITLE
Release prep: align formula desc with positioning

### DIFF
--- a/packaging/yapcode.rb
+++ b/packaging/yapcode.rb
@@ -9,7 +9,7 @@
 # tarball over anonymous HTTPS, which 404s on a private repo. Publish only after
 # the repo is public and a release tag exists.
 class Yapcode < Formula
-  desc "Voice front-end for Claude Code — talk to drive real Claude Code sessions"
+  desc "Voice agent for Claude Code — talk to drive real Claude Code sessions"
   homepage "https://github.com/nithiink/yapcode"
   url "https://github.com/nithiink/yapcode/archive/refs/tags/v0.1.0.tar.gz"
   sha256 "0000000000000000000000000000000000000000000000000000000000000000" # PLACEHOLDER — release.sh stamps this


### PR DESCRIPTION
Formula `desc` now says **voice agent** (matching the repo description and README) instead of the older "voice front-end" wording — so the v0.1.0 tag ships consistent naming.

Part of cutting `v0.1.0` + standing up the Homebrew tap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)