### PR TITLE
fix(plugin): /voice-handoff blocked by shell permission checker on fresh installs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
       "name": "yapcode",
       "source": "./integrations/claude-code-plugin",
       "description": "Hand off a terminal Claude Code session to the yapcode voice agent — continue your work by voice while still typing in the same session.",
-      "version": "0.1.0"
+      "version": "0.1.1"
     }
   ]
 }

--- a/integrations/claude-code-plugin/.claude-plugin/plugin.json
+++ b/integrations/claude-code-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "yapcode",
   "description": "Hand off a terminal Claude Code session to the yapcode voice agent — continue your work by voice while still typing in the same session.",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "author": { "name": "yapcode" },
   "homepage": "https://github.com/nithiink/yapcode"
 }

--- a/integrations/claude-code-plugin/skills/voice-handoff/SKILL.md
+++ b/integrations/claude-code-plugin/skills/voice-handoff/SKILL.md
@@ -1,20 +1,20 @@
 ---
 name: voice-handoff
 description: Hand off THIS terminal Claude Code session to the yapcode voice agent so you can continue it by voice (while still typing in the same session). Runs on /voice-handoff.
-allowed-tools: Bash(curl:*)
+allowed-tools: Bash(bash:*)
 disable-model-invocation: true
 ---
 
 # voice-handoff
 
-Register the current session with the local yapcode backend. `${CLAUDE_SESSION_ID}`
-is substituted by Claude Code; `$(pwd)` / `$TMUX` are evaluated by the shell. The backend
-URL/token default to localhost and can be overridden with the `YAPCODE_URL` /
+Register the current session with the local yapcode backend. `${CLAUDE_SESSION_ID}` is
+substituted by Claude Code; the script picks up the working directory and `$TMUX` itself.
+The backend URL/token default to localhost and can be overridden with the `YAPCODE_URL` /
 `YAPCODE_TOKEN` environment variables.
 
 Backend response:
 
-!`curl -s -X POST "${YAPCODE_URL:-http://localhost:8000}/session/handoff" -H "Content-Type: application/json" ${YAPCODE_TOKEN:+-H "X-VC-Token: ${YAPCODE_TOKEN}"} -d "{\"session_id\":\"${CLAUDE_SESSION_ID}\",\"cwd\":\"$(pwd)\",\"tmux\":\"${TMUX:-}\"}" || echo '{"error":"could not reach yapcode — is the backend running at '"${YAPCODE_URL:-http://localhost:8000}"'?"}'`
+!`bash "${CLAUDE_PLUGIN_ROOT}/skills/voice-handoff/handoff.sh" ${CLAUDE_SESSION_ID}`
 
 Using the JSON response above, tell the user in one or two short sentences:
 

--- a/integrations/claude-code-plugin/skills/voice-handoff/handoff.sh
+++ b/integrations/claude-code-plugin/skills/voice-handoff/handoff.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Registers the current Claude Code session with the local yapcode backend.
+# Invoked by the /voice-handoff skill as: handoff.sh <claude-session-id>
+#
+# Lives in a script (rather than inline in SKILL.md) because Claude Code's
+# shell-permission checker rejects inline commands that put quotes inside
+# ${...} expansions ("expansion obfuscation") — which the token header needs.
+# Always exits 0 and prints JSON; failures are reported in an "error" field.
+set -u
+
+url="${YAPCODE_URL:-http://localhost:8000}"
+sid="${1:-}"
+
+if [ -z "$sid" ]; then
+  echo '{"error":"missing session id — expected: handoff.sh <claude-session-id>"}'
+  exit 0
+fi
+
+args=(-s -X POST "$url/session/handoff" -H "Content-Type: application/json")
+if [ -n "${YAPCODE_TOKEN:-}" ]; then
+  args+=(-H "X-VC-Token: ${YAPCODE_TOKEN}")
+fi
+
+payload="$(printf '{"session_id":"%s","cwd":"%s","tmux":"%s"}' "$sid" "$(pwd)" "${TMUX:-}")"
+
+curl "${args[@]}" -d "$payload" ||
+  printf '{"error":"could not reach yapcode — is the backend running at %s?"}\n' "$url"
+exit 0


### PR DESCRIPTION
## Problem

On a fresh install (`claude plugin install yapcode@yapcode`), running `/voice-handoff` fails immediately:

```
Error: Shell command permission check failed for pattern "!curl ... ${YAPCODE_TOKEN:+-H "X-VC-Token: ..."} ...":
Contains brace with quote character (expansion obfuscation)
```

Claude Code's shell-permission checker hard-blocks inline commands that put quote characters inside `${...}` expansions. The skill's one-liner needed exactly that to conditionally send the auth header — so the plugin's core command was broken for every new user. (It worked in dev sessions only because of previously accumulated permission grants.)

Found during a from-scratch installation test of the public repo.

## Fix

- Move the request into `skills/voice-handoff/handoff.sh`; the skill's inline command is now a plain `bash "${CLAUDE_PLUGIN_ROOT}/skills/voice-handoff/handoff.sh" ${CLAUDE_SESSION_ID}` — nothing for the checker to flag.
- Identical behavior: defaults to `http://localhost:8000`, honors `YAPCODE_URL` / `YAPCODE_TOKEN`, always exits 0 and prints JSON (failures in an `"error"` field, which the skill already knows how to relay).
- `allowed-tools` updated `Bash(curl:*)` → `Bash(bash:*)` to match.
- Plugin version bumped to **0.1.1** (`plugin.json` + `marketplace.json`).

## Tested

- `bash -n` clean; missing-arg and unreachable-backend paths print proper error JSON, exit 0.
- Live test against a running backend: request lands, sandbox correctly rejects a disallowed cwd (fail-closed), no junk session created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)