### PR TITLE
fix: switching permission mode no longer leaves a pending prompt hanging

### DIFF
--- a/backend/claude_runner.py
+++ b/backend/claude_runner.py
@@ -23,7 +23,7 @@ from uuid import uuid4
 
 import claude_agent_sdk as sdk
 
-from permissions import classify, is_plan_file_write
+from permissions import classify, is_plan_file_write, mode_covers
 from event_log import log_event
 
 log = logging.getLogger("yapcode.runner")
@@ -353,6 +353,13 @@ class SDKClaudeRunner(ClaudeRunner):
         if s.client:
             await s.client.set_permission_mode(mode)
         s.mode = mode
+        # set_permission_mode affects FUTURE tool calls only — a can_use_tool
+        # callback already parked on s._decision keeps waiting. If the new mode
+        # would have auto-approved that tool, resolve the prompt now so
+        # 'switch to auto mode' doesn't leave it hanging.
+        if (s.pending and s.pending.kind == "permission"
+                and mode_covers(mode, s.pending.tool_name)):
+            self.start_answer(handle, "allow")
         return mode
 
     async def read(self, handle: str) -> str:
@@ -397,7 +404,8 @@ class SDKClaudeRunner(ClaudeRunner):
             # agent that wasn't connected when it fired can still see it.
             if s.pending is not None:
                 d["prompt"] = {"kind": s.pending.kind, "text": s.pending.text,
-                               "options": list(s.pending.options or [])}
+                               "options": list(s.pending.options or []),
+                               "tool_name": s.pending.tool_name}
             out.append(d)
         return out
 

--- a/backend/permissions.py
+++ b/backend/permissions.py
@@ -27,6 +27,19 @@ def is_edit_tool(tool_name: str) -> bool:
     return tool_name in EDIT_TOOLS
 
 
+def mode_covers(mode: str, tool_name: str) -> bool:
+    """True when a permission mode would auto-approve this tool's permission
+    prompt — used to resolve a prompt that's already pending when the user
+    switches modes mid-prompt ('switch to auto mode' shouldn't leave the
+    prompt hanging). auto approves everything; acceptEdits approves file
+    edits only."""
+    if mode == "auto":
+        return True
+    if mode == "acceptEdits":
+        return tool_name in EDIT_TOOLS
+    return False
+
+
 _PLANS_DIR = os.path.realpath(os.path.expanduser("~/.claude/plans"))
 
 

--- a/backend/tmux_runner.py
+++ b/backend/tmux_runner.py
@@ -44,7 +44,7 @@ from claude_runner import (
     _summarize_tool,
     normalize_mode,
 )
-from permissions import classify
+from permissions import classify, mode_covers
 from event_log import log_event
 
 log = logging.getLogger("yapcode.tmux")
@@ -885,6 +885,15 @@ class TmuxClaudeRunner(ClaudeRunner):
         reach the target — no blind guessing."""
         s = self._get(handle)
         target = normalize_mode(mode)
+        if (s.pending and s.pending.kind == "permission"
+                and s.pending.tool_name == "ExitPlanMode"):
+            # The plan-approval dialog is on screen; BTab presses would land in
+            # the dialog, not the footer. The dialog itself offers the mode
+            # change (option 1 is 'auto mode'), so route through answer instead.
+            raise ValueError(
+                "a plan-approval dialog is open — answer it instead "
+                "(e.g. 'auto mode' to approve the plan and auto-apply, or "
+                "'manually approve edits')")
         async with s._turn_lock:  # don't toggle mid-turn
             if not await self._alive(s):
                 raise ValueError("session is not running")
@@ -896,6 +905,18 @@ class TmuxClaudeRunner(ClaudeRunner):
             await asyncio.sleep(0.2)
             s.mode = self._detect_mode(await self._capture(s))
             self._write_mode(s)  # keep the hook's view of the mode in sync
+        # The mode file only affects FUTURE tool calls — a PreToolUse hook
+        # already parked on a permission prompt keeps waiting for its decision
+        # file. If the new mode would have auto-approved that tool, approve it
+        # now so 'switch to auto mode' doesn't leave the prompt hanging; the
+        # resumed turn's output is delivered via poll_status like any answer.
+        if (s.pending and s.pending.kind == "permission"
+                and mode_covers(s.mode, s.pending.tool_name)):
+            log_event("backend", "claude", "decision",
+                      f"allow (pending prompt covered by switch to {s.mode})",
+                      session=_slabel(s),
+                      detail={"handle": s.handle, "tool_name": s.pending.tool_name})
+            self.start_answer(handle, "allow")
         return s.mode
 
     # read_session output lands in a voice model's context (Gemini Live runs a
@@ -989,7 +1010,8 @@ class TmuxClaudeRunner(ClaudeRunner):
             # expose it here so a later-connecting agent can still see it.
             if s.pending is not None:
                 d["prompt"] = {"kind": s.pending.kind, "text": s.pending.text,
-                               "options": list(s.pending.options or [])}
+                               "options": list(s.pending.options or []),
+                               "tool_name": s.pending.tool_name}
             out.append(d)
         return out
 

--- a/backend/tools.py
+++ b/backend/tools.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import time
 from typing import Any
 
+from permissions import mode_covers
 from session_manager import (
     backend_of,
     cli_pane_for,
@@ -169,7 +170,7 @@ TOOL_DEFINITIONS: list[dict[str, Any]] = [
     {
         "type": "function",
         "name": "set_mode",
-        "description": "Change a Claude session's permission mode when the user asks (e.g. 'switch to plan mode', 'turn on auto', 'accept edits', 'go back to normal'). Modes: 'default' (Claude asks before risky actions and you relay allow/deny by voice), 'plan' (Claude only plans, makes NO edits or commands), 'acceptEdits' (file edits auto-apply, other risky actions still asked), 'auto' (Claude runs everything without asking — no voice approval). Returns the mode now in effect.",
+        "description": "Change a Claude session's permission mode when the user asks (e.g. 'switch to plan mode', 'turn on auto', 'accept edits', 'go back to normal'). Modes: 'default' (Claude asks before risky actions and you relay allow/deny by voice), 'plan' (Claude only plans, makes NO edits or commands), 'acceptEdits' (file edits auto-apply, other risky actions still asked), 'auto' (Claude runs everything without asking — no voice approval). Returns the mode now in effect. If a permission prompt is pending and the new mode would auto-approve that tool (auto: anything; acceptEdits: file edits), the prompt is approved automatically and the session continues — the result message says which happened, so relay it.",
         "parameters": {
             "type": "object",
             "properties": {
@@ -320,8 +321,22 @@ async def dispatch_tool(name: str, args: dict[str, Any]) -> dict[str, Any]:
 
     if name == "set_mode":
         sid = resolve_session(args["session_id"])
+        # Snapshot any pending permission BEFORE the switch: the runner resolves
+        # a covered prompt asynchronously, so checking afterwards would race.
+        sess = next((x for x in list_all_sessions() if x["handle"] == sid), None)
+        prompt = (sess or {}).get("prompt")
         mode = await set_session_mode(sid, args["mode"])
-        return {"session_id": sid, "mode": mode}
+        out = {"session_id": sid, "mode": mode}
+        if prompt and prompt.get("kind") == "permission":
+            if mode_covers(mode, prompt.get("tool_name", "")):
+                out["message"] = (f"Mode is now '{mode}'. The pending permission "
+                                  f"({prompt['text']}) was approved under the new mode — "
+                                  "the session is continuing.")
+            else:
+                out["message"] = (f"Mode is now '{mode}', but the pending permission "
+                                  f"({prompt['text']}) is NOT covered by it and still "
+                                  "needs an allow/deny from the user.")
+        return out
 
     if name == "list_slash_commands":
         cwd: str | None = None


### PR DESCRIPTION
## Problem

With a permission prompt pending, saying **"switch to auto mode"** changed the mode — but the prompt stayed, and the user still had to answer it. Defeats the point of switching to auto mid-prompt.

Root cause (both backends): a mode change only affects **future** tool calls.
- **tmux backend**: the PreToolUse hook had already parked waiting for its decision file; `set_mode` cycles Shift+Tab and updates the mode file, which the parked hook never re-reads.
- **SDK backend**: `set_permission_mode` doesn't resolve the `can_use_tool` future already awaiting a decision.

## Fix

- `permissions.mode_covers(mode, tool_name)` — would this mode have auto-approved this tool? (`auto` → anything, `acceptEdits` → file edit tools.)
- Both runners' `set_mode`: if the pending permission is covered by the new mode, resolve it as **allow** via the existing `start_answer` path — so the resumed turn's output lands in `_pending_results` and is narrated by `poll_status`, exactly like a spoken "allow".
- If the prompt is **not** covered (e.g. `acceptEdits` while a Bash prompt is pending), it stays pending — and the `set_mode` tool result now says so explicitly, so the voice agent tells the user instead of leaving them confused.
- `list()` prompt dicts now include `tool_name` (needed for the coverage message; useful to late-connecting agents anyway).
- Edge case: with the **plan-approval dialog** (ExitPlanMode) on screen, tmux `set_mode` errors with guidance to answer the dialog instead — BTab presses would land in the dialog, whose option 1 *is* the mode switch.

## Tested

- All four modules parse and import cleanly in the backend venv.
- `mode_covers` truth table verified (auto×anything, acceptEdits×edit/non-edit, default/plan never).
- Live voice re-test after merge: trigger a Bash permission prompt, say "switch to auto mode" → prompt should clear and the turn continue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)