### PR TITLE
ui: recommend Claude CLI backend with any voice provider

### DIFF
--- a/frontend/components/VoiceAgent.tsx
+++ b/frontend/components/VoiceAgent.tsx
@@ -1520,7 +1520,7 @@ export default function VoiceAgent() {
         </div>
       ) : (
         <div className="ctrlcap">
-          <span className="ck">✓</span> Recommended: <b>Claude CLI</b> backend — works with any voice provider
+          <span className="ck">✓</span> Recommended: <b>Claude CLI</b> with any voice provider
         </div>
       )}
 

--- a/frontend/components/VoiceAgent.tsx
+++ b/frontend/components/VoiceAgent.tsx
@@ -1520,7 +1520,7 @@ export default function VoiceAgent() {
         </div>
       ) : (
         <div className="ctrlcap">
-          <span className="ck">✓</span> Recommended: <b>Gemini</b> voice + <b>Claude CLI</b>
+          <span className="ck">✓</span> Recommended: <b>Claude CLI</b> backend — works with any voice provider
         </div>
       )}
 


### PR DESCRIPTION
## Summary
- The disconnected-state hint under the connection controls previously recommended a specific voice provider: **"Recommended: Gemini voice + Claude CLI"**.
- It now reads **"Recommended: Claude CLI backend — works with any voice provider"** — the recommendation is about the execution backend (CLI vs SDK), not about which voice model to pick.

## Why
Gemini, OpenAI, and Azure are all first-class voice transports; singling out Gemini in the UI was misleading. The part of the recommendation that actually matters is using the Claude CLI backend (real TUI, Max subscription, session rehydration).

## Changes
- `frontend/components/VoiceAgent.tsx` — one-line copy change in the `ctrlcap` hint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)