### PR TITLE
security: fail-closed permission decisions + keep TLS verification in LAN mode

### DIFF
--- a/backend/tmux_runner.py
+++ b/backend/tmux_runner.py
@@ -603,7 +603,22 @@ class TmuxClaudeRunner(ClaudeRunner):
 
     def _write_decision(self, s: _TmuxSession, choice: str) -> bool:
         c = (choice or "").strip().lower()
-        allow = c in _ALLOW_WORDS or any(c.startswith(w) for w in _ALLOW_WORDS)
+        # This gate approves/denies risky tool calls, so it must fail CLOSED on
+        # ambiguous speech. Any negation anywhere in the phrase wins over a
+        # leading affirmative word: spoken corrections like "yeah, no — cancel"
+        # or "ok wait, stop" are denials, not approvals (the old code only
+        # prefix-matched affirmatives and would have approved both).
+        tokens = re.findall(r"[a-z']+", c)
+        deny = (any(t in _DENY_WORDS for t in tokens)
+                or any(p in c for p in ("don't", "do not", "stop", "cancel",
+                                        "decline", "reject", "nope", "nah")))
+        # Match affirmatives only at a word boundary so a single-letter word like
+        # "y" cannot swallow unrelated words ("your call, deny that").
+        first = tokens[0] if tokens else ""
+        allow = (not deny) and (
+            c in _ALLOW_WORDS
+            or first in _ALLOW_WORDS
+            or any(c.startswith(w + " ") for w in _ALLOW_WORDS))
         path = os.path.join(s.ctrl, "decisions", f"{s.pending_tool_use_id or 'none'}.json")
         tmp = path + ".tmp"
         with open(tmp, "w") as f:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,7 @@
   "comment": "Exact-pinned versions, audited clean (npm audit: 0 vulnerabilities). package-lock.json pins + hashes the full transitive tree; install with `npm ci`.",
   "scripts": {
     "dev": "next dev -H 127.0.0.1 -p 3000",
-    "dev:network": "BACKEND_URL=https://localhost:8000 NODE_TLS_REJECT_UNAUTHORIZED=0 next dev --experimental-https --experimental-https-key ./.certs/dev-key.pem --experimental-https-cert ./.certs/dev-cert.pem -H 0.0.0.0 -p 3000",
+    "dev:network": "BACKEND_URL=https://localhost:8000 NODE_EXTRA_CA_CERTS=./.certs/dev-cert.pem next dev --experimental-https --experimental-https-key ./.certs/dev-key.pem --experimental-https-cert ./.certs/dev-cert.pem -H 0.0.0.0 -p 3000",
     "build": "next build",
     "start": "next start -H 127.0.0.1 -p 3000"
   },


### PR DESCRIPTION
Minimal, targeted fixes for the verified findings in the daily security review. Fixes #23.

## Fixes

### H1 — Permission-approval gate fails open on ambiguous voice input
**File:** `backend/tmux_runner.py` (`_write_decision`)

The gate that approves/denies risky Claude tool calls classified a choice as **allow** whenever the text merely *started with* an affirmative word — and since `_ALLOW_WORDS` includes the single letter `"y"`, almost any "y…" phrase matched. It also never checked deny-words first, so corrections like `"yeah, no — cancel"`, `"ok wait, stop"`, or `"your call, deny that"` silently approved the operation.

**Change:** scan for any negation token anywhere in the phrase (deny wins over a leading affirmative) and match affirmatives only at a word boundary — mirroring the deny-first ordering already used by the sibling `_classify_plan_choice`. The gate now fails **closed** on ambiguity. Verified that plain affirmatives (`yes`, `ok`, `go ahead`, `do it now`, `okay sounds good`) still approve, while denials and mixed corrections deny.

### M1 — TLS certificate verification disabled in LAN-exposed mode
**File:** `frontend/package.json` (`dev:network` script)

`NODE_TLS_REJECT_UNAUTHORIZED=0` disabled TLS validation process-wide while the server binds `0.0.0.0` and forwards the `X-VC-Token` secret to `https://localhost:8000` — MITM-able on the LAN. Replaced with `NODE_EXTRA_CA_CERTS=./.certs/dev-cert.pem` (the cert the backend actually serves, per `backend/run-network.sh`), so the known dev cert is trusted but verification stays on.

## Left for manual review (not auto-fixed)
- **M2** — `_detect_mode` derives permission mode from a spoofable terminal screen-scrape (`backend/tmux_runner.py:870`). Fixing it touches the `set_mode` keypress-count logic, so it needs human review rather than an automated patch.
- **L1–L5** — `send_keys` gating, `proxyAuth` CSRF heuristic hardening, `BACKEND_URL` bundling, token-in-URL logging, unescaped-JSON shell scripts. Low/informational; see #23.

🤖 Generated by the scheduled daily security review.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GMLDoHpQMGV22C7xKRzgW2)_