### PR TITLE
chore: cap uvicorn graceful-shutdown so reload/stop doesn't hang

### DIFF
--- a/backend/run-network.sh
+++ b/backend/run-network.sh
@@ -26,9 +26,12 @@ fi
 # reload preserves running CLI sessions (they're rehydrated on the restart).
 # --reload-dir . limits the watcher to backend/ so the session store under the
 # project root (rapidly-written events.jsonl) never triggers reloads.
+# --timeout-graceful-shutdown: long-lived SSE/poll/terminal-WS connections
+# never drain on their own, so a reload (or stop) would hang on "Waiting for
+# connections to close". 3s lets an in-flight request finish, then force-closes.
 exec .venv/bin/python -m uvicorn main:app \
   --host 0.0.0.0 --port 8000 \
   --ssl-keyfile ../frontend/.certs/dev-key.pem \
   --ssl-certfile ../frontend/.certs/dev-cert.pem \
   --log-level info \
-  --reload --reload-dir .
+  --reload --reload-dir . --timeout-graceful-shutdown 3

--- a/backend/run.sh
+++ b/backend/run.sh
@@ -8,5 +8,10 @@ cd "$(dirname "$0")"
 # reload preserves running CLI sessions (they're rehydrated on the restart).
 # --reload-dir . limits the watcher to backend/ so the session store under the
 # project root (rapidly-written events.jsonl) never triggers reloads.
+# --timeout-graceful-shutdown: the app holds long-lived connections (the SSE
+# debug/event stream, the poll loop, the xterm terminal WebSockets) that never
+# drain on their own, so a reload would otherwise hang on "Waiting for
+# connections to close" and the new worker can't bind :8000. 3s lets an
+# in-flight request finish, then force-closes so the reload completes.
 exec .venv/bin/python -m uvicorn main:app --port 8000 --log-level info \
-  --reload --reload-dir .
+  --reload --reload-dir . --timeout-graceful-shutdown 3

--- a/bin/yapcode
+++ b/bin/yapcode
@@ -354,7 +354,12 @@ cmd_up() {
   mkdir -p "$STATE_DIR"
   local fe_log="$STATE_DIR/frontend.log"
 
-  ( cd "$APP_ROOT/backend" && exec .venv/bin/python -m uvicorn main:app --port 8000 --log-level info ) &
+  # --timeout-graceful-shutdown: the app holds long-lived connections (the
+  # debug/event SSE stream, the poll loop, the xterm terminal WebSockets) that
+  # never drain on their own. Without a cap, stopping yapcode (Ctrl-C → the
+  # trap below SIGTERMs uvicorn) hangs on "Waiting for connections to close"
+  # until a second Ctrl-C. 3s lets a real in-flight request finish, then exits.
+  ( cd "$APP_ROOT/backend" && exec .venv/bin/python -m uvicorn main:app --port 8000 --log-level info --timeout-graceful-shutdown 3 ) &
   local back=$!
 
   # Dev vs. prod detection. `next build` (production) is the ONLY thing that


### PR DESCRIPTION
## Problem

The backend holds long-lived connections — the SSE debug/event stream, the poll loop, and the xterm terminal WebSockets — that never drain on their own. uvicorn's default graceful shutdown waits for them **indefinitely**:

- **Dev** (`run.sh` / `run-network.sh`): a `--reload` hangs on `Waiting for connections to close. (CTRL+C to force quit)`, the old worker keeps `:8000`, the new one can't bind → manual `kill -9` on every backend edit.
- **Prod** (`yapcode up`): Ctrl-C SIGTERMs uvicorn through the launcher's `trap`, which hangs the same way → the user has to Ctrl-C **twice** to stop the app.

## Fix

`--timeout-graceful-shutdown 3` on all three uvicorn invocations. An in-flight request still has time to finish; then the stuck long-lived connections are force-closed and shutdown completes. Nothing is lost — CLI sessions live in tmux and rehydrate on restart, and the frontend reconnects its SSE/WS automatically.

`yapcode up` gets it too, so it's a real **user-facing** stop-experience fix, not just dev ergonomics.

## Verified

Touching a backend file now reloads straight through to `Application startup complete` on its own instead of hanging; backend + frontend both 200 after. All three scripts pass `bash -n`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)