### PR TITLE
security: strict allow/deny permission gate (fail-closed, with re-ask)

### DIFF
--- a/backend/claude_runner.py
+++ b/backend/claude_runner.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import re
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Any, Literal, Optional
@@ -38,6 +39,27 @@ _ALLOW_WORDS = {
 
 # Bare declines (no feedback attached) for the plan-approval dialog.
 _DENY_WORDS = {"deny", "no", "nope", "decline", "declined", "cancel", "reject", "rejected", "n"}
+
+# Negations that aren't single tokens (caught as substrings, not word matches).
+_DENY_PHRASES = ("don't", "do not", "stop")
+
+
+def decide_permission(choice: str) -> Optional[str]:
+    """Resolve a binary permission answer to "allow", "deny", or None (ambiguous).
+
+    A SECURITY gate that fails CLOSED: matching is word-level (not the old
+    `startswith`, which let "y" match "your"), any negation wins, and anything
+    that isn't a clean allow/deny returns None so the caller re-asks.
+    """
+    c = (choice or "").strip().lower()
+    if not c:
+        return None
+    tokens = set(re.findall(r"[a-z']+", c))
+    if tokens & _DENY_WORDS or any(p in c for p in _DENY_PHRASES):
+        return "deny"
+    if c in _ALLOW_WORDS or (tokens & _ALLOW_WORDS):
+        return "allow"
+    return None
 
 
 @dataclass
@@ -480,16 +502,27 @@ class SDKClaudeRunner(ClaudeRunner):
 
         async with s._perm_lock:           # serialize concurrent risky/question asks
             loop = asyncio.get_running_loop()
-            fut: asyncio.Future[str] = loop.create_future()
-            s._decision = fut
-            s.pending = self._build_prompt(kind, tool_name, tool_input)
-            s.status = "needs_choice" if kind == "question" else "needs_permission"
-            log_event("claude", "backend", "hook",
-                      f"needs {'choice' if kind == 'question' else 'permission'}: {s.pending.text}",
-                      session=s.session_id or s.handle[:8],
-                      detail={"handle": s.handle, "tool_name": tool_name})
-            s._stop.set()                  # let advance/answer return with the prompt
-            choice = await fut             # parked until answer() resolves
+            while True:
+                fut: asyncio.Future[str] = loop.create_future()
+                s._decision = fut
+                s.pending = self._build_prompt(kind, tool_name, tool_input)
+                s.status = "needs_choice" if kind == "question" else "needs_permission"
+                log_event("claude", "backend", "hook",
+                          f"needs {'choice' if kind == 'question' else 'permission'}: {s.pending.text}",
+                          session=s.session_id or s.handle[:8],
+                          detail={"handle": s.handle, "tool_name": tool_name})
+                s._stop.set()              # let advance/answer return with the prompt
+                choice = await fut         # parked until answer() resolves
+                # Re-ask an ambiguous binary permission (fail closed); questions
+                # and the plan dialog have their own non-binary handling.
+                if (kind != "permission" or tool_name == "ExitPlanMode"
+                        or decide_permission(choice) is not None):
+                    break
+                log_event("backend", "claude", "decision",
+                          f"ambiguous, re-asking: {choice}",
+                          session=s.session_id or s.handle[:8],
+                          detail={"handle": s.handle, "tool_name": tool_name,
+                                  "choice": choice})
             s._decision = None
             s.pending = None
             log_event("backend", "claude", "decision", str(choice),
@@ -534,7 +567,15 @@ class SDKClaudeRunner(ClaudeRunner):
             # Best-effort: allow the tool with the selection injected.
             # AskUserQuestion's exact answer schema is verified in the e2e step.
             return sdk.PermissionResultAllow(updated_input={**tool_input, "answer": choice})
-        if c in _ALLOW_WORDS or any(c.startswith(w) for w in _ALLOW_WORDS):
+        if tool_name == "ExitPlanMode":
+            # Plan approval isn't binary: "auto"/"manual"/"proceed" leave plan
+            # mode; anything else keeps planning and forwards the text as feedback.
+            if (decide_permission(choice) == "allow"
+                    or any(w in c for w in ("auto", "manual", "proceed", "approve"))):
+                return sdk.PermissionResultAllow()
+            return sdk.PermissionResultDeny(message=f"Keep planning: {choice}")
+        # Binary permission: approve only on a clean allow (ambiguity re-asked above).
+        if decide_permission(choice) == "allow":
             return sdk.PermissionResultAllow()
         return sdk.PermissionResultDeny(message=f"User declined: {choice}")
 

--- a/backend/tmux_runner.py
+++ b/backend/tmux_runner.py
@@ -40,6 +40,7 @@ from claude_runner import (
     Status,
     _ALLOW_WORDS,
     _DENY_WORDS,
+    decide_permission,
     _parse_questions,
     _summarize_tool,
     normalize_mode,
@@ -535,7 +536,15 @@ class TmuxClaudeRunner(ClaudeRunner):
                     # plan renders on screen; the TUI dialog is the actual gate.
                     await self._drive_plan_dialog(s, choice)
                 else:
-                    self._write_decision(s, choice)
+                    decided = self._write_decision(s, choice)
+                    if decided is None:
+                        # Ambiguous: keep the prompt pending and re-ask. The hook
+                        # stays parked (no decision written), so the gate holds.
+                        s.status = "needs_permission"
+                        s._delta.append(
+                            "I didn't catch a clear yes or no — say 'allow' to "
+                            "approve or 'deny' to reject.")
+                        return self._collect(s)
             else:  # choice / AskUserQuestion menu
                 more = await self._answer_question(s, choice)
                 if more:
@@ -601,34 +610,28 @@ class TmuxClaudeRunner(ClaudeRunner):
         if probe in input_line:
             await self._tmux("send-keys", "-t", s.pane, "Enter")
 
-    def _write_decision(self, s: _TmuxSession, choice: str) -> bool:
-        c = (choice or "").strip().lower()
-        # This gate approves/denies risky tool calls, so it must fail CLOSED on
-        # ambiguous speech. Any negation anywhere in the phrase wins over a
-        # leading affirmative word: spoken corrections like "yeah, no — cancel"
-        # or "ok wait, stop" are denials, not approvals (the old code only
-        # prefix-matched affirmatives and would have approved both).
-        tokens = re.findall(r"[a-z']+", c)
-        deny = (any(t in _DENY_WORDS for t in tokens)
-                or any(p in c for p in ("don't", "do not", "stop", "cancel",
-                                        "decline", "reject", "nope", "nah")))
-        # Match affirmatives only at a word boundary so a single-letter word like
-        # "y" cannot swallow unrelated words ("your call, deny that").
-        first = tokens[0] if tokens else ""
-        allow = (not deny) and (
-            c in _ALLOW_WORDS
-            or first in _ALLOW_WORDS
-            or any(c.startswith(w + " ") for w in _ALLOW_WORDS))
+    def _write_decision(self, s: _TmuxSession, choice: str) -> bool | None:
+        """Write the decision file the parked PreToolUse hook waits on. Returns
+        True/False (allowed/denied), or None on an ambiguous answer — in which
+        case no file is written, so the hook stays parked and the caller re-asks."""
+        decision = decide_permission(choice)
+        if decision is None:
+            log_event("backend", "claude", "decision", f"ambiguous, re-asking: {choice}",
+                      session=_slabel(s),
+                      detail={"handle": s.handle, "choice": choice,
+                              "tool_use_id": s.pending_tool_use_id})
+            return None
+        allow = decision == "allow"
         path = os.path.join(s.ctrl, "decisions", f"{s.pending_tool_use_id or 'none'}.json")
         tmp = path + ".tmp"
         with open(tmp, "w") as f:
-            json.dump({"decision": "allow" if allow else "deny",
+            json.dump({"decision": decision,
                        "reason": "" if allow else f"user said: {choice}"}, f)
         os.replace(tmp, path)
         log_event("backend", "claude", "decision",
-                  f"{'allow' if allow else 'deny'}" + (f" ({choice})" if not allow else ""),
+                  decision + (f" ({choice})" if not allow else ""),
                   session=_slabel(s),
-                  detail={"handle": s.handle, "decision": "allow" if allow else "deny",
+                  detail={"handle": s.handle, "decision": decision,
                           "choice": choice, "tool_use_id": s.pending_tool_use_id})
         return allow
 


### PR DESCRIPTION
Follow-up to #24 (the H1 hotfix). #24 made the permission gate fail closed but kept the fuzzy keyword matching and **only patched the tmux runner** — the SDK runner (`claude_runner.py`) still had the original fail-open logic. This PR replaces the keyword matching with an explicit, auditable contract and fixes both runners consistently. Relates to #23.

## The design

A binary permission answer ("may Claude run this `Bash`/`Write`?") is now treated as a strict enum, resolved by one shared helper:

```python
decide_permission(choice) -> "allow" | "deny" | None
```

- **Word-level exact matching, never prefix/substring.** The old `any(c.startswith(w) for w in _ALLOW_WORDS)` let the single-letter allow-word `"y"` swallow unrelated words — `"your call, deny that"` was read as **allow**.
- **Any negation wins (deny-first).** The old code never checked deny-words first, so `"yeah, no — cancel"` (starts with "yeah") was read as **allow**.
- **Ambiguous → `None`.** Anything that isn't an unambiguous allow/deny is not guessed at — the caller re-asks. A security gate must never approve on a fuzzy match.

The voice agent already owns turning natural speech into `allow`/`deny` (that's the documented `answer_prompt` contract); this just makes the backend verify the answer is unambiguous and **fail closed** when it isn't.

## What changed

**`claude_runner.py`**
- New shared `decide_permission()` helper (replaces the inline `startswith` matching at the old line 533 — the fail-open bug #24 missed).
- `_can_use_tool`: ambiguous binary-permission answers re-park and re-ask via the same `_stop`/future handshake used for the initial prompt.
- `_map_decision`: approves only on a clean `allow`.

**`tmux_runner.py`**
- `_write_decision`: returns `True`/`False`/`None`; on ambiguous it writes **no** decision file, so the PreToolUse hook stays parked and nothing is approved.
- `answer()`: on `None`, keeps the prompt pending and asks the agent for a clear yes/no.

**Non-binary prompts keep their natural-language handling** — `AskUserQuestion` menus and the `ExitPlanMode` plan dialog (auto / manual / decline + feedback) are routed around the strict gate and are never re-asked.

## Testing
- Both modules `py_compile` clean.
- Unit-tested `decide_permission` across clean allows, clean denies, the former fail-open phrases (now `deny`), and genuinely-unclear input (now `None`).

## Review focus
The SDK runner's re-ask loop (`_can_use_tool`) re-parks via `s._stop.set()` + a fresh future, mirroring the initial prompt path. I reasoned through the `answer()`/`_stop` handshake but could not exercise the full async stack here — worth a careful look during review.

🤖 Generated as a follow-up to the daily security review.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GMLDoHpQMGV22C7xKRzgW2)_