### PR TITLE
fix: reconstruct Claude cost from token usage for the CLI backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,6 +474,7 @@ config-dir file for any key set in both; the config-dir file is authoritative on
 | `VC_ALLOWED_ORIGIN_REGEX` | _(LAN regex)_ | Overrides the default private-LAN origin regex (localhost/127.0.0.1/::1 + 10.x/192.168.x/172.16–31.x); set empty to disable LAN origins. |
 | `VC_SESSION_STORE` | `<repo>/.yapcode/tmux` | Session control-dir root (tmux sessions, `meta.json`, `events.jsonl`, …). |
 | `VC_COST_LOG_PATH` | `<repo>/cost-log.jsonl` | Append-only cost log. |
+| `VC_PRICING_JSON` | _(built-in rates)_ | JSON object overriding per-model list pricing, e.g. `{"opus":{"input":5,"output":25}}` (USD per 1M tokens, matched by model-id substring). The CLI backend has no dollar figure in its transcript (Max subscription), so the displayed "Claude $…" is reconstructed from per-message token usage × these rates; cache reads bill at 0.1× input, 5-min cache writes at 1.25×, 1-hour writes at 2×. |
 | `VC_DEBUG_LOG_PATH` | `<repo>/debug-log.jsonl` | Append-only pipeline event log. |
 | `VC_DEBUG_LOG_FILE` | `1` | Set `0` to keep debug events in-memory/SSE only (no file). |
 | `VC_DEBUG_BUFFER` | `3000` | In-memory ring-buffer size for the event bus. |

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -68,3 +68,10 @@ ALLOWED_PROJECT_ROOTS=/Users/YOUR_USERNAME/YOUR_DEVELOPMENT_FOLDER
 # Defaults to <project>/.yapcode/tmux (gitignored). Point it elsewhere,
 # e.g. ~/.yapcode/tmux, if you'd rather keep it outside the repo.
 # VC_SESSION_STORE=
+
+# Override per-model list pricing used to reconstruct the displayed Claude cost.
+# The CLI (Max-subscription) backend has no dollar figure in its transcript, so
+# cost is computed from per-message token usage × these rates (USD per 1M
+# tokens, matched by model-id substring). Cache reads bill at 0.1× input,
+# 5-minute cache writes at 1.25×, 1-hour writes at 2×. Unset = built-in rates.
+# VC_PRICING_JSON={"opus":{"input":5,"output":25},"sonnet":{"input":3,"output":15},"haiku":{"input":1,"output":5}}

--- a/backend/pricing.py
+++ b/backend/pricing.py
@@ -1,20 +1,13 @@
 """Token-usage → USD cost estimation for Claude models.
 
 The interactive CLI backend runs on a Max subscription, so the session JSONL
-never reports a dollar figure (`total_cost_usd` is an SDK-only field). But every
-assistant message in the transcript carries a full `usage` block — input,
-output, cache-write, and cache-read token counts — so we can reconstruct the
-*API-equivalent* cost the same usage would have billed at standard rates. That's
-what the UI's "Claude $…" readout shows for CLI sessions.
+never reports a dollar figure (`total_cost_usd` is SDK-only). But each assistant
+message carries a full `usage` block, so we reconstruct the *API-equivalent*
+cost the same usage would bill at list rates — that's the UI's "Claude $…"
+readout for CLI sessions.
 
-Rates are list prices per 1M tokens, sourced from the Claude model catalog
-(see the claude-api skill). Cache economics follow the documented multipliers:
-cache *read* = 0.1× input, cache *write* (5-minute TTL) = 1.25× input,
-cache *write* (1-hour TTL) = 2× input.
-
-Override or extend the table via `VC_PRICING_JSON` (a JSON object mapping a
-model-id substring to `{"input": x, "output": y}` per-MTok rates) so a new model
-or a negotiated rate can be wired in without a code change.
+Rates are list prices per 1M tokens. Override the table via `VC_PRICING_JSON`
+(a JSON object mapping a model-id substring to `{"input": x, "output": y}`).
 """
 from __future__ import annotations
 

--- a/backend/pricing.py
+++ b/backend/pricing.py
@@ -1,0 +1,130 @@
+"""Token-usage → USD cost estimation for Claude models.
+
+The interactive CLI backend runs on a Max subscription, so the session JSONL
+never reports a dollar figure (`total_cost_usd` is an SDK-only field). But every
+assistant message in the transcript carries a full `usage` block — input,
+output, cache-write, and cache-read token counts — so we can reconstruct the
+*API-equivalent* cost the same usage would have billed at standard rates. That's
+what the UI's "Claude $…" readout shows for CLI sessions.
+
+Rates are list prices per 1M tokens, sourced from the Claude model catalog
+(see the claude-api skill). Cache economics follow the documented multipliers:
+cache *read* = 0.1× input, cache *write* (5-minute TTL) = 1.25× input,
+cache *write* (1-hour TTL) = 2× input.
+
+Override or extend the table via `VC_PRICING_JSON` (a JSON object mapping a
+model-id substring to `{"input": x, "output": y}` per-MTok rates) so a new model
+or a negotiated rate can be wired in without a code change.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Any
+
+log = logging.getLogger("yapcode.pricing")
+
+# Per-million-token list prices (USD). Keyed by a substring matched against the
+# transcript's model id (e.g. "claude-opus-4-8"). Order matters: the first key
+# found as a substring wins, so list more specific keys before generic ones.
+_BASE_RATES: list[tuple[str, dict[str, float]]] = [
+    ("opus",   {"input": 5.0,  "output": 25.0}),
+    ("sonnet", {"input": 3.0,  "output": 15.0}),
+    ("haiku",  {"input": 1.0,  "output": 5.0}),
+]
+
+# Cache multipliers relative to the input rate (documented, model-independent).
+_CACHE_READ_MULT = 0.1
+_CACHE_WRITE_5M_MULT = 1.25
+_CACHE_WRITE_1H_MULT = 2.0
+
+# Fallback when the model can't be classified — assume the most expensive tier
+# so we never silently under-report. Opus is the CLI default model.
+_DEFAULT_RATE = {"input": 5.0, "output": 25.0}
+
+
+def _load_overrides() -> dict[str, dict[str, float]]:
+    raw = os.getenv("VC_PRICING_JSON")
+    if not raw:
+        return {}
+    try:
+        obj = json.loads(raw)
+        if isinstance(obj, dict):
+            return obj
+    except Exception:
+        log.warning("ignoring malformed VC_PRICING_JSON")
+    return {}
+
+
+def _rate_for(model: str | None) -> dict[str, float]:
+    """Per-MTok {input, output} rate for a model id, or the Opus-tier default."""
+    m = (model or "").lower()
+    for key, rate in _load_overrides().items():
+        if key.lower() in m and "input" in rate and "output" in rate:
+            return rate
+    for key, rate in _BASE_RATES:
+        if key in m:
+            return rate
+    return _DEFAULT_RATE
+
+
+def cost_for_usage(model: str | None, usage: dict[str, Any]) -> float:
+    """USD cost for one assistant message's `usage` block.
+
+    Recognized token fields (all optional, default 0):
+      input_tokens                 — uncached input, billed at full input rate
+      output_tokens                — billed at the output rate
+      cache_read_input_tokens      — billed at 0.1× input
+      cache_creation_input_tokens  — cache writes; split by TTL when the
+                                     `cache_creation` breakdown is present, else
+                                     billed at the 5-minute write rate
+    """
+    if not isinstance(usage, dict):
+        return 0.0
+    rate = _rate_for(model)
+    in_rate = rate["input"] / 1_000_000
+    out_rate = rate["output"] / 1_000_000
+
+    def _int(v: Any) -> int:
+        return v if isinstance(v, int) else 0
+
+    cost = _int(usage.get("input_tokens")) * in_rate
+    cost += _int(usage.get("output_tokens")) * out_rate
+    cost += _int(usage.get("cache_read_input_tokens")) * in_rate * _CACHE_READ_MULT
+
+    # Cache writes: prefer the per-TTL breakdown (1-hour writes cost 2× vs the
+    # 1.25× of 5-minute writes); fall back to the flat total as a 5-minute write.
+    breakdown = usage.get("cache_creation")
+    if isinstance(breakdown, dict):
+        w5 = _int(breakdown.get("ephemeral_5m_input_tokens"))
+        w1 = _int(breakdown.get("ephemeral_1h_input_tokens"))
+        cost += w5 * in_rate * _CACHE_WRITE_5M_MULT
+        cost += w1 * in_rate * _CACHE_WRITE_1H_MULT
+    else:
+        cost += _int(usage.get("cache_creation_input_tokens")) * in_rate * _CACHE_WRITE_5M_MULT
+
+    return cost
+
+
+def cost_for_transcript_lines(lines: list[str]) -> float:
+    """Sum API-equivalent cost across assistant messages in JSONL lines.
+
+    Each assistant line is `{"type": "assistant", "message": {"model", "usage"}}`.
+    Non-assistant lines, malformed JSON, and lines without usage are skipped.
+    """
+    total = 0.0
+    for raw in lines:
+        if not raw.strip():
+            continue
+        try:
+            o = json.loads(raw)
+        except Exception:
+            continue
+        if o.get("type") != "assistant":
+            continue
+        msg = o.get("message") or {}
+        usage = msg.get("usage")
+        if isinstance(usage, dict):
+            total += cost_for_usage(msg.get("model"), usage)
+    return total

--- a/backend/tests/test_pricing.py
+++ b/backend/tests/test_pricing.py
@@ -1,0 +1,110 @@
+"""Tests for cost reconstruction from transcript token usage (backend/pricing.py).
+
+Runs under pytest, or standalone: `python3 backend/tests/test_pricing.py`.
+No third-party deps — pricing.py is pure stdlib.
+"""
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import pricing
+
+# Per-MTok list rates the tests assert against (kept in sync with pricing._BASE_RATES).
+OPUS_IN, OPUS_OUT = 5.0 / 1e6, 25.0 / 1e6
+SONNET_IN, SONNET_OUT = 3.0 / 1e6, 15.0 / 1e6
+HAIKU_IN, HAIKU_OUT = 1.0 / 1e6, 5.0 / 1e6
+
+
+def _close(a, b, tol=1e-9):
+    return abs(a - b) <= tol
+
+
+def test_input_and_output_priced_per_model():
+    assert _close(pricing.cost_for_usage("claude-opus-4-8", {"input_tokens": 1_000_000}), 5.0)
+    assert _close(pricing.cost_for_usage("claude-opus-4-8", {"output_tokens": 1_000_000}), 25.0)
+    assert _close(pricing.cost_for_usage("claude-sonnet-4-6", {"input_tokens": 1_000_000}), 3.0)
+    assert _close(pricing.cost_for_usage("claude-haiku-4-5", {"output_tokens": 1_000_000}), 5.0)
+
+
+def test_cache_read_is_tenth_of_input():
+    cost = pricing.cost_for_usage("claude-opus-4-8", {"cache_read_input_tokens": 1_000_000})
+    assert _close(cost, 5.0 * 0.1)  # 0.5
+
+
+def test_cache_write_ttl_breakdown():
+    # 5-minute writes bill at 1.25× input, 1-hour writes at 2× input.
+    usage = {"cache_creation": {"ephemeral_5m_input_tokens": 1_000_000,
+                                "ephemeral_1h_input_tokens": 1_000_000}}
+    cost = pricing.cost_for_usage("claude-opus-4-8", usage)
+    assert _close(cost, 5.0 * 1.25 + 5.0 * 2.0)  # 6.25 + 10.0
+
+
+def test_cache_write_flat_total_defaults_to_5m_rate():
+    # No per-TTL breakdown → treat the flat total as a 5-minute write (1.25×).
+    cost = pricing.cost_for_usage("claude-opus-4-8", {"cache_creation_input_tokens": 1_000_000})
+    assert _close(cost, 5.0 * 1.25)  # 6.25
+
+
+def test_real_transcript_message():
+    # A real assistant `usage` block captured from a CLI session.
+    usage = {"input_tokens": 3239, "cache_creation_input_tokens": 4402,
+             "cache_read_input_tokens": 16213, "output_tokens": 369,
+             "cache_creation": {"ephemeral_1h_input_tokens": 4402,
+                                "ephemeral_5m_input_tokens": 0}}
+    expected = (3239 * OPUS_IN + 369 * OPUS_OUT
+                + 16213 * OPUS_IN * 0.1 + 4402 * OPUS_IN * 2.0)
+    assert _close(pricing.cost_for_usage("claude-opus-4-8", usage), expected)
+    assert pricing.cost_for_usage("claude-opus-4-8", usage) > 0  # the bug was always-zero
+
+
+def test_unknown_model_falls_back_to_opus_tier():
+    # Never silently under-report: an unrecognized model bills at the top tier.
+    assert _close(pricing.cost_for_usage("some-future-model", {"input_tokens": 1_000_000}), 5.0)
+
+
+def test_missing_or_malformed_usage_is_zero():
+    assert pricing.cost_for_usage("claude-opus-4-8", {}) == 0.0
+    assert pricing.cost_for_usage("claude-opus-4-8", None) == 0.0
+    assert pricing.cost_for_usage(None, {"input_tokens": 100}) > 0  # None model → default rate
+
+
+def test_transcript_lines_sum_only_assistant_usage():
+    lines = [
+        json.dumps({"type": "user", "message": {"content": "hi"}}),
+        json.dumps({"type": "assistant",
+                    "message": {"model": "claude-opus-4-8",
+                                "usage": {"output_tokens": 1_000_000}}}),
+        json.dumps({"type": "assistant",
+                    "message": {"model": "claude-sonnet-4-6",
+                                "usage": {"input_tokens": 1_000_000}}}),
+        "",                       # blank line
+        "{not valid json",        # malformed
+        json.dumps({"type": "assistant", "message": {"model": "claude-opus-4-8"}}),  # no usage
+    ]
+    # opus output 25.0 + sonnet input 3.0
+    assert _close(pricing.cost_for_transcript_lines(lines), 25.0 + 3.0)
+
+
+def test_env_override(monkeypatch=None):
+    # VC_PRICING_JSON lets a new/negotiated rate be wired in without code change.
+    os.environ["VC_PRICING_JSON"] = json.dumps({"opus": {"input": 99.0, "output": 1.0}})
+    try:
+        assert _close(pricing.cost_for_usage("claude-opus-4-8", {"input_tokens": 1_000_000}), 99.0)
+    finally:
+        del os.environ["VC_PRICING_JSON"]
+
+
+if __name__ == "__main__":
+    fns = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failed = 0
+    for fn in fns:
+        try:
+            fn()
+            print(f"ok   {fn.__name__}")
+        except AssertionError as e:
+            failed += 1
+            print(f"FAIL {fn.__name__}: {e}")
+    print(f"\n{len(fns) - failed}/{len(fns)} passed")
+    sys.exit(1 if failed else 0)

--- a/backend/tests/test_pricing.py
+++ b/backend/tests/test_pricing.py
@@ -30,7 +30,7 @@ def test_input_and_output_priced_per_model():
 
 def test_cache_read_is_tenth_of_input():
     cost = pricing.cost_for_usage("claude-opus-4-8", {"cache_read_input_tokens": 1_000_000})
-    assert _close(cost, 5.0 * 0.1)  # 0.5
+    assert _close(cost, 5.0 * 0.1)
 
 
 def test_cache_write_ttl_breakdown():
@@ -38,13 +38,13 @@ def test_cache_write_ttl_breakdown():
     usage = {"cache_creation": {"ephemeral_5m_input_tokens": 1_000_000,
                                 "ephemeral_1h_input_tokens": 1_000_000}}
     cost = pricing.cost_for_usage("claude-opus-4-8", usage)
-    assert _close(cost, 5.0 * 1.25 + 5.0 * 2.0)  # 6.25 + 10.0
+    assert _close(cost, 5.0 * 1.25 + 5.0 * 2.0)
 
 
 def test_cache_write_flat_total_defaults_to_5m_rate():
     # No per-TTL breakdown → treat the flat total as a 5-minute write (1.25×).
     cost = pricing.cost_for_usage("claude-opus-4-8", {"cache_creation_input_tokens": 1_000_000})
-    assert _close(cost, 5.0 * 1.25)  # 6.25
+    assert _close(cost, 5.0 * 1.25)
 
 
 def test_real_transcript_message():

--- a/backend/tests/test_tmux_cost.py
+++ b/backend/tests/test_tmux_cost.py
@@ -1,0 +1,111 @@
+"""Integration test for cost wiring in the CLI (tmux) runner.
+
+Verifies TmuxClaudeRunner._update_cost reads a session transcript, sums the
+API-equivalent cost, and caches by file size so a static transcript isn't
+re-scanned. This is the path that fixes the "Claude $0.0000 always" bug for the
+default (CLI) backend.
+
+Requires the backend deps (claude_agent_sdk) — run with the project venv:
+    backend/.venv/bin/python backend/tests/test_tmux_cost.py
+Skips cleanly if the SDK isn't importable.
+"""
+import json
+import os
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+try:
+    import tmux_runner
+except ModuleNotFoundError as e:
+    print(f"SKIP test_tmux_cost: {e} (run with the backend venv)")
+    sys.exit(0)
+
+
+def _write_transcript(path, messages):
+    with open(path, "w", encoding="utf-8") as f:
+        for m in messages:
+            f.write(json.dumps(m) + "\n")
+
+
+def _make_session(handle, transcript_path):
+    s = tmux_runner._TmuxSession(handle, cwd="/tmp", model="opus")
+    s.transcript_path = transcript_path  # _find_transcript returns this if it exists
+    return s
+
+
+def test_update_cost_sums_transcript():
+    runner = tmux_runner.TmuxClaudeRunner()
+    with tempfile.TemporaryDirectory() as d:
+        tp = os.path.join(d, "sess.jsonl")
+        _write_transcript(tp, [
+            {"type": "user", "message": {"content": "hi"}},
+            {"type": "assistant", "message": {"model": "claude-opus-4-8",
+                                              "usage": {"output_tokens": 1_000_000}}},
+        ])
+        s = _make_session("h1", tp)
+        runner._update_cost(s)
+        assert abs(s.cost_usd - 25.0) < 1e-9, s.cost_usd
+
+
+def test_update_cost_is_cached_until_file_grows():
+    runner = tmux_runner.TmuxClaudeRunner()
+    with tempfile.TemporaryDirectory() as d:
+        tp = os.path.join(d, "sess.jsonl")
+        _write_transcript(tp, [
+            {"type": "assistant", "message": {"model": "claude-opus-4-8",
+                                              "usage": {"output_tokens": 1_000_000}}},
+        ])
+        s = _make_session("h2", tp)
+        runner._update_cost(s)
+        first = s.cost_usd
+        assert abs(first - 25.0) < 1e-9
+
+        # Mutate cost_usd out-of-band; a same-size file must NOT trigger a re-scan.
+        s.cost_usd = -1.0
+        runner._update_cost(s)
+        assert s.cost_usd == -1.0, "unchanged transcript should hit the size cache"
+
+        # Append a new assistant turn → file grows → re-scan picks up both turns.
+        with open(tp, "a", encoding="utf-8") as f:
+            f.write(json.dumps({"type": "assistant",
+                                "message": {"model": "claude-opus-4-8",
+                                            "usage": {"input_tokens": 1_000_000}}}) + "\n")
+        runner._update_cost(s)
+        assert abs(s.cost_usd - (25.0 + 5.0)) < 1e-9, s.cost_usd
+
+
+def test_update_cost_no_transcript_is_safe():
+    runner = tmux_runner.TmuxClaudeRunner()
+    s = _make_session("h3", "/nonexistent/path.jsonl")
+    runner._update_cost(s)
+    assert s.cost_usd == 0.0
+
+
+def test_list_reports_nonzero_cost():
+    runner = tmux_runner.TmuxClaudeRunner()
+    with tempfile.TemporaryDirectory() as d:
+        tp = os.path.join(d, "sess.jsonl")
+        _write_transcript(tp, [
+            {"type": "assistant", "message": {"model": "claude-opus-4-8",
+                                              "usage": {"output_tokens": 1_000_000}}},
+        ])
+        s = _make_session("h4", tp)
+        runner._sessions[s.handle] = s
+        listed = runner.list()
+        assert listed and abs(listed[0]["cost_usd"] - 25.0) < 1e-9, listed
+
+
+if __name__ == "__main__":
+    fns = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failed = 0
+    for fn in fns:
+        try:
+            fn()
+            print(f"ok   {fn.__name__}")
+        except AssertionError as e:
+            failed += 1
+            print(f"FAIL {fn.__name__}: {e}")
+    print(f"\n{len(fns) - failed}/{len(fns)} passed")
+    sys.exit(1 if failed else 0)

--- a/backend/tmux_runner.py
+++ b/backend/tmux_runner.py
@@ -47,6 +47,7 @@ from claude_runner import (
 )
 from permissions import classify, mode_covers
 from event_log import log_event
+import pricing
 
 log = logging.getLogger("yapcode.tmux")
 
@@ -140,7 +141,12 @@ class _TmuxSession:
         self.status: Status = "running"
         self.turn_prompt: str | None = None  # message of the in-flight turn (narration attribution)
         self.error: str | None = None
-        self.cost_usd = 0.0                 # interactive = subscription, no $ in jsonl
+        # Subscription billing means no dollar figure in the jsonl, so cost is
+        # reconstructed from per-message token usage × list pricing (see
+        # _update_cost). _cost_scan_size caches the transcript byte-size of the
+        # last scan so polling list() calls don't re-read an unchanged file.
+        self.cost_usd = 0.0
+        self._cost_scan_size = -1
         self._delta: list[str] = []
         self._transcript: list[str] = []
         self.tools_used: list[str] = []
@@ -1021,8 +1027,10 @@ class TmuxClaudeRunner(ClaudeRunner):
     def list(self) -> list[dict]:
         out: list[dict] = []
         for s in self._sessions.values():
+            self._update_cost(s)
             d = {"handle": s.handle, "session_id": s.handle, "cwd": s.cwd,
-                 "model": s.model, "mode": s.mode, "status": s.status, "cost_usd": 0.0,
+                 "model": s.model, "mode": s.mode, "status": s.status,
+                 "cost_usd": round(s.cost_usd, 4),
                  **self._queue_counts(s)}
             # A prompt's needs_* result is delivered exactly once via poll_status;
             # expose it here so a later-connecting agent can still see it.
@@ -1374,6 +1382,32 @@ class TmuxClaudeRunner(ClaudeRunner):
                         s.tools_used.append(b.get("name", ""))
         return "".join(out)
 
+    def _update_cost(self, s: _TmuxSession) -> None:
+        """Refresh s.cost_usd from the full transcript's token usage.
+
+        Reads the whole jsonl and sums API-equivalent cost across every
+        assistant message — accurate regardless of resume (a resumed session's
+        prior turns still count). Cheap on repeat calls: if the transcript's
+        byte-size is unchanged since the last scan, the cached value is kept, so
+        the frequent polling list()/poll path doesn't re-read a static file.
+        """
+        path = self._find_transcript(s)
+        if not path or not os.path.exists(path):
+            return
+        try:
+            size = os.path.getsize(path)
+        except OSError:
+            return
+        if size == s._cost_scan_size:
+            return
+        try:
+            with open(path, encoding="utf-8", errors="replace") as f:
+                lines = f.readlines()
+        except OSError:
+            return
+        s.cost_usd = pricing.cost_for_transcript_lines(lines)
+        s._cost_scan_size = size
+
     def _find_transcript(self, s: _TmuxSession) -> str | None:
         if s.transcript_path and os.path.exists(s.transcript_path):
             return s.transcript_path
@@ -1394,9 +1428,12 @@ class TmuxClaudeRunner(ClaudeRunner):
     def _collect(self, s: _TmuxSession) -> AdvanceResult:
         text = "".join(s._delta)
         s._delta.clear()
+        # The just-finished turn appended new usage to the transcript; refresh
+        # so the turn result carries the up-to-date cumulative cost.
+        self._update_cost(s)
         return AdvanceResult(
             status=s.status, assistant_text=text, prompt=s.pending,
-            error=s.error, session_id=s.handle, cost_usd=0.0,
+            error=s.error, session_id=s.handle, cost_usd=round(s.cost_usd, 4),
             request=s.turn_prompt,
         )
 

--- a/backend/tmux_runner.py
+++ b/backend/tmux_runner.py
@@ -141,10 +141,9 @@ class _TmuxSession:
         self.status: Status = "running"
         self.turn_prompt: str | None = None  # message of the in-flight turn (narration attribution)
         self.error: str | None = None
-        # Subscription billing means no dollar figure in the jsonl, so cost is
-        # reconstructed from per-message token usage × list pricing (see
-        # _update_cost). _cost_scan_size caches the transcript byte-size of the
-        # last scan so polling list() calls don't re-read an unchanged file.
+        # Subscription billing reports no $ in the jsonl, so cost is rebuilt from
+        # token usage × list pricing (see _update_cost). _cost_scan_size caches
+        # the last-scanned transcript size so polling doesn't re-read it.
         self.cost_usd = 0.0
         self._cost_scan_size = -1
         self._delta: list[str] = []
@@ -1428,9 +1427,7 @@ class TmuxClaudeRunner(ClaudeRunner):
     def _collect(self, s: _TmuxSession) -> AdvanceResult:
         text = "".join(s._delta)
         s._delta.clear()
-        # The just-finished turn appended new usage to the transcript; refresh
-        # so the turn result carries the up-to-date cumulative cost.
-        self._update_cost(s)
+        self._update_cost(s)  # the finished turn added usage to the transcript
         return AdvanceResult(
             status=s.status, assistant_text=text, prompt=s.pending,
             error=s.error, session_id=s.handle, cost_usd=round(s.cost_usd, 4),


### PR DESCRIPTION
## Problem

The UI's **"Claude \$…"** readout always showed **\$0.0000**.

The default backend is `cli` → `TmuxClaudeRunner`, which drives the interactive `claude` CLI on a Max subscription. It **hardcoded `cost_usd = 0.0`** everywhere (`tmux_runner.py:143`, `list()`, `_collect()`) — comment: *"interactive = subscription, no \$ in jsonl"*. Since the frontend sums each session's `cost_usd` (`VoiceAgent.tsx:520`), the total was always zero.

The `SDKClaudeRunner` path was already correct (reads `msg.total_cost_usd`) and is left untouched.

## Insight

Although the subscription reports no dollar figure, **every assistant message in the Claude Code transcript JSONL carries a full `usage` block** (input / output / cache-creation / cache-read tokens, with a 5m-vs-1h cache-write breakdown). So API-equivalent cost can be reconstructed from usage × list pricing.

## Changes

- **`backend/pricing.py`** (new): `cost_for_usage()` / `cost_for_transcript_lines()`. Per-MTok list rates (Opus \$5/\$25, Sonnet \$3/\$15, Haiku \$1/\$5) with documented cache multipliers (read 0.1×, 5-min write 1.25×, 1-hour write 2×) and per-TTL breakdown when present. Overridable via `VC_PRICING_JSON`; unknown models fall back to the Opus tier so cost is never under-reported.
- **`backend/tmux_runner.py`**: `TmuxClaudeRunner._update_cost()` scans the transcript and sums cost (accurate across resume), cached by file byte-size so polling `list()` calls don't re-read a static file. Wired into `list()` and `_collect()`.
- **Tests**: `backend/tests/test_pricing.py` (9) + `backend/tests/test_tmux_cost.py` (4) — pure-stdlib, run under pytest or standalone. All 13 pass.
- **Docs**: `README.md` + `backend/.env.example` document `VC_PRICING_JSON`.

## Verification

A real 2998-line Opus session that previously displayed \$0.0000 now reports **\$223.06** of API-equivalent usage.

## Configuration

None required — built-in rates apply by default. Optionally set `VC_PRICING_JSON` to override rates without a code change.

> Note: cost is **API-equivalent list pricing**, not actual Max-subscription spend (flat fee). Happy to relabel as "Claude (API-equiv) \$…" if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)