### PR TITLE
Fix setup wizard leaking pasted API keys (terminal echo race)

### DIFF
--- a/bin/yapcode
+++ b/bin/yapcode
@@ -64,8 +64,20 @@ read_secret() { # read_secret "Prompt" -> echoes secret, never echoes keystrokes
 # terminates the read, equivalent to pressing Enter). EOF before any Enter
 # aborts so we never write a half-baked config.
 read_secret_optional() { # read_secret_optional "Prompt" -> echoes (possibly empty) secret
-  local q="$1" s="" c="" got_enter=0
+  local q="$1" s="" c="" got_enter=0 saved=""
   printf '%s: ' "$q" >&2
+  # Disable terminal echo for the WHOLE read, not per-keystroke. `read -s` toggles
+  # echo on/off around each -rsn1 call, so during a paste the characters arriving
+  # between calls leak to the screen as plaintext (mixed in with the • mask). Hold
+  # noecho across the entire loop with stty, and restore it on every exit path. If
+  # there's no tty (piped input), stty -g fails and we fall back gracefully.
+  saved="$(stty -g 2>/dev/null || true)"
+  if [ -n "$saved" ]; then
+    stty -echo 2>/dev/null || true
+    # Restore the terminal if the user interrupts mid-prompt, so Ctrl-C never
+    # leaves the shell stuck in noecho.
+    trap 'stty "$saved" 2>/dev/null; printf "\n" >&2; exit 130' INT
+  fi
   # With -n1, `read` returns success on Enter (delivering c="") and on any
   # normal key; it returns non-zero only at EOF. So we loop, and the moment we
   # see an empty c from a *successful* read we know it was Enter and stop.
@@ -77,6 +89,7 @@ read_secret_optional() { # read_secret_optional "Prompt" -> echoes (possibly emp
       *) s="$s$c"; printf '•' >&2 ;;
     esac
   done
+  if [ -n "$saved" ]; then stty "$saved" 2>/dev/null || true; trap - INT; fi # restore echo
   if [ "$got_enter" -eq 0 ]; then # loop ended via read failure = EOF, never Enter
     printf '\n' >&2; err "yapcode: no input — aborting setup"; exit 1
   fi


### PR DESCRIPTION
## Problem
In the first-run wizard, pasting an API key (most noticeably the long OpenAI key) shows the raw key on screen mixed in with the `•` mask, instead of being fully hidden.

## Cause
`read_secret_optional` reads one character at a time with `read -rsn1` and prints a `•` per char. `read -s` enables noecho only for the duration of *each* call and restores it afterward — so during a fast paste, characters arriving in the gap *between* calls are echoed by the terminal as plaintext. Both key prompts use this function; paste just makes it visible.

## Fix
Hold the terminal in noecho for the **entire** read with `stty -echo` instead of per-keystroke, and restore it on every exit path:
- normal completion / EOF → restore + `trap - INT`
- Ctrl-C mid-prompt → `trap` restores echo then exits 130 (the old per-char code happened to be safe here; this keeps it safe)
- no tty (piped input) → `stty -g` fails, falls back gracefully

Keystrokes are now always masked; live `•` feedback is preserved.

## Testing
- `bash -n` passes.
- Wizard still captures both keys via piped input (exercises the no-tty fallback).
- Manual: paste a long key into both prompts — only `•` appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)