### PR TITLE
fix(network): dev cert needs CA:TRUE for Node 26 fetch trust

### DIFF
--- a/frontend/.certs/san.cnf.example
+++ b/frontend/.certs/san.cnf.example
@@ -5,6 +5,10 @@ prompt = no
 [dn]
 CN = yapcode-dev
 [v3_req]
+# CA:TRUE lets this self-signed cert serve as its own trust anchor, so the
+# Next /api proxy (Node fetch, NODE_EXTRA_CA_CERTS) can trust it WITHOUT
+# disabling TLS verification. Browsers/phones accept it the usual way.
+basicConstraints = critical, CA:TRUE
 subjectAltName = @alt
 [alt]
 # Set IP.1 to your machine's LAN IP (macOS: ipconfig getifaddr en0; Linux: hostname -I).


### PR DESCRIPTION
## Problem
In network mode, the Next `/api/*` routes proxy to the HTTPS backend over loopback. Node 26's `fetch`/undici rejects the self-signed dev cert (`DEPTH_ZERO_SELF_SIGNED_CERT`) even with `NODE_EXTRA_CA_CERTS` pointed at it, because the cert lacks `basicConstraints = CA:TRUE` and can't be used as a trust anchor.

## Fix
Add `basicConstraints = critical, CA:TRUE` to `san.cnf.example`. The self-signed cert can then serve as its own trust anchor, so `NODE_EXTRA_CA_CERTS` trusts it **with verification still ON** — no `NODE_TLS_REJECT_UNAUTHORIZED=0`.

Verified: regenerated cert → isolated HTTPS server + `NODE_EXTRA_CA_CERTS` fetch → `200`.

## Note for existing users
Regenerate the cert (`cp san.cnf.example san.cnf`, set LAN IP, re-run the openssl command) and re-accept it on devices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)