### PR TITLE
fix(network): working TLS for the dev proxy + printed phone URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,6 +386,9 @@ is just a remote.
 3. Open `https://192.168.1.42:3000/#vc_token=<your token>` — the app stores the token and strips
    it from the address bar. Allow **microphone** access when prompted.
 
+   > 💡 You don't have to type this URL: `npm run dev:network` **prints the full
+   > phone URL** (IP + token) at startup — just open it on your phone.
+
 **Every time after that:** just open `https://192.168.1.42:3000` — talk, watch the terminal,
 approve permission prompts from the couch, the kitchen, anywhere on the network.
 

--- a/frontend/.certs/san.cnf.example
+++ b/frontend/.certs/san.cnf.example
@@ -5,10 +5,6 @@ prompt = no
 [dn]
 CN = yapcode-dev
 [v3_req]
-# CA:TRUE lets this self-signed cert serve as its own trust anchor, so the
-# Next /api proxy (Node fetch, NODE_EXTRA_CA_CERTS) can trust it WITHOUT
-# disabling TLS verification. Browsers/phones accept it the usual way.
-basicConstraints = critical, CA:TRUE
 subjectAltName = @alt
 [alt]
 # Set IP.1 to your machine's LAN IP (macOS: ipconfig getifaddr en0; Linux: hostname -I).

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,7 @@
   "comment": "Exact-pinned versions, audited clean (npm audit: 0 vulnerabilities). package-lock.json pins + hashes the full transitive tree; install with `npm ci`.",
   "scripts": {
     "dev": "next dev -H 127.0.0.1 -p 3000",
-    "dev:network": "BACKEND_URL=https://localhost:8000 NODE_EXTRA_CA_CERTS=./.certs/dev-cert.pem next dev --experimental-https --experimental-https-key ./.certs/dev-key.pem --experimental-https-cert ./.certs/dev-cert.pem -H 0.0.0.0 -p 3000",
+    "dev:network": "node scripts/phone-url.mjs; BACKEND_URL=https://localhost:8000 NODE_TLS_REJECT_UNAUTHORIZED=0 next dev --experimental-https --experimental-https-key ./.certs/dev-key.pem --experimental-https-cert ./.certs/dev-cert.pem -H 0.0.0.0 -p 3000",
     "build": "next build",
     "start": "next start -H 127.0.0.1 -p 3000"
   },

--- a/frontend/scripts/phone-url.mjs
+++ b/frontend/scripts/phone-url.mjs
@@ -1,0 +1,67 @@
+// Prints ready-to-open URLs (with the auth token) when network mode starts, so
+// you can open the app on your phone without hand-assembling the #vc_token URL.
+// Reads VC_AUTH_TOKEN from ../backend/.env and detects your LAN IP. Best-effort:
+// never fails the dev server (any error just prints a hint instead).
+import { readFileSync } from "node:fs";
+import { networkInterfaces, homedir } from "node:os";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+// Candidate config locations, in the order run-network.sh / the launcher resolve
+// them: the in-tree backend/.env (what run-network.sh reads), then the
+// out-of-tree config dir (Homebrew / YAPCODE_CONFIG_DIR / XDG).
+const cfgDir =
+  process.env.YAPCODE_CONFIG_DIR ||
+  join(process.env.XDG_CONFIG_HOME || join(homedir(), ".config"), "yapcode");
+const envPaths = [join(here, "..", "..", "backend", ".env"), join(cfgDir, ".env")];
+
+function lanIP() {
+  const addrs = [];
+  for (const iface of Object.values(networkInterfaces())) {
+    for (const i of iface || []) {
+      if (i.family === "IPv4" && !i.internal) addrs.push(i.address);
+    }
+  }
+  return (
+    addrs.find((a) => a.startsWith("192.168.")) ||
+    addrs.find((a) => a.startsWith("10.")) ||
+    addrs.find((a) => /^172\.(1[6-9]|2\d|3[01])\./.test(a)) ||
+    addrs[0] ||
+    "<your-LAN-IP>"
+  );
+}
+
+function token() {
+  if (process.env.VC_AUTH_TOKEN) return process.env.VC_AUTH_TOKEN.trim();
+  for (const p of envPaths) {
+    try {
+      const m = readFileSync(p, "utf8").match(/^\s*VC_AUTH_TOKEN\s*=\s*(.+?)\s*$/m);
+      let t = m ? m[1].trim() : "";
+      if ((t.startsWith('"') && t.endsWith('"')) || (t.startsWith("'") && t.endsWith("'"))) {
+        t = t.slice(1, -1);
+      }
+      if (t) return t;
+    } catch {
+      /* try next candidate */
+    }
+  }
+  return "";
+}
+
+const ip = lanIP();
+const t = token();
+const frag = t ? `/#vc_token=${t}` : "";
+const tokenNote = t
+  ? ""
+  : "\n  ⚠ No VC_AUTH_TOKEN in backend/.env — network mode needs one (run-network.sh sets it up).";
+const bar = "─".repeat(64);
+
+process.stdout.write(
+  `\n${bar}\n` +
+    ` yapcode — network mode\n\n` +
+    ` 📱 On your phone (same Wi-Fi):\n    https://${ip}:3000${frag}\n\n` +
+    ` 💻 On this computer:\n    https://localhost:3000${frag}\n\n` +
+    ` ℹ️  First time on each device: open https://${ip}:8000 and accept the cert.${tokenNote}\n` +
+    `${bar}\n\n`,
+);


### PR DESCRIPTION
## Problems
1. **Network mode was broken on Node 22+/26.** The Next `/api/*` routes proxy to the HTTPS backend, but Next's bundled `fetch` ignores `NODE_EXTRA_CA_CERTS` (which `dev:network` relied on), so every hop failed with `DEPTH_ZERO_SELF_SIGNED_CERT`. (Plain `node` honors it; Next does not — which is why it looked fixable via the cert but wasn't.)
2. **Phone onboarding was fiddly** — you had to hand-assemble `https://<ip>:3000/#vc_token=<token>`.

## Fix
- `dev:network` → `NODE_TLS_REJECT_UNAUTHORIZED=0` (this is what the README config table already documents). The only server-side fetch is the **loopback** Next→backend hop on the same machine, so disabling verification there is a no-op for security; the boundary stays `VC_AUTH_TOKEN`.
- New `scripts/phone-url.mjs` prints the ready-to-open phone + desktop URLs (LAN IP + token) at startup. Token resolved from env → `backend/.env` → config dir, best-effort (never fails the dev server).
- Reverted the `CA:TRUE` cert tweak from #33 — it only mattered for the `NODE_EXTRA_CA_CERTS` path, now gone. Existing certs keep working.

## Verified
- `phone-url.mjs` prints correct URL with token (env + file paths) and degrades gracefully with none.
- `NODE_TLS_REJECT_UNAUTHORIZED=0` fetch against the backend → `200` (tested earlier this session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)