### PR TITLE
fix(security): reject same-site requests in CSRF proxy guard

### DIFF
--- a/frontend/lib/proxyAuth.ts
+++ b/frontend/lib/proxyAuth.ts
@@ -39,8 +39,8 @@ export function forwardAuth(
 // which the browser hits at :8000 without a proxy in between).
 //
 // Why this is reliable: `Sec-Fetch-Site` is set by the browser and cannot be
-// forged or removed by page JS, so a value other than same-origin/same-site is
-// proof the request did not originate from our own page. For the rare client
+// forged or removed by page JS, so any value other than same-origin is proof
+// the request did not originate from our own page. For the rare client
 // that omits it we fall back to comparing the Origin's host to the request Host
 // (a cross-site POST always carries an Origin). Non-browser callers (curl,
 // native apps) send neither signal and are NOT a CSRF vector — they carry no
@@ -49,8 +49,13 @@ export function forwardAuth(
 export function isCrossSiteRequest(req: NextRequest): boolean {
   const site = req.headers.get("sec-fetch-site");
   if (site) {
-    // same-origin / same-site = ours; cross-site / none = not from our page.
-    return site !== "same-origin" && site !== "same-site";
+    // The legitimate frontend ALWAYS calls these routes same-origin (a relative
+    // `fetch("/api/...")` from the app's own page), so only same-origin is ours.
+    // Accept nothing else: `same-site` would trust any other origin on the same
+    // host (e.g. a different localhost/LAN port), which could drive the
+    // command-executing proxy via CSRF. `cross-site` / `none` are likewise not
+    // from our page.
+    return site !== "same-origin";
   }
   const origin = req.headers.get("origin");
   if (origin) {


### PR DESCRIPTION
Fixes the Medium finding from the daily security review (#36).

## Fix mapped to finding

### M1 — Over-permissive CSRF check accepted `Sec-Fetch-Site: same-site`
- **File:** `frontend/lib/proxyAuth.ts`
- `blockCrossSite()` is the sole CSRF boundary for the `/api/*` proxy, which forwards to a backend that turns requests into real command execution (`/api/tools/execute`). In zero-config localhost mode the backend trusts the loopback proxy, so this heuristic is the only gate.
- The legitimate frontend **always** calls these routes `same-origin` (relative `fetch("/api/...")`) — it never relies on `same-site`. Because "site" ignores the port, accepting `same-site` trusted any other origin on the same host but a different port (e.g. `http://localhost:9999` → `http://localhost:3000`), letting attacker-controlled local web content drive command execution via CSRF.
- **Change:** accept only `same-origin`. Zero functional impact on the legitimate same-origin client; pure attack-surface reduction. Doc comments updated to match.

## Left for manual attention (not in this PR)
The two **Low** JSON-injection-hygiene findings (`integrations/claude-code-plugin/bin/yapcode:22`, `skills/voice-handoff/handoff.sh:24`) are not auto-fixed because the recommended remediation (`jq -n --arg ...`) introduces a new `jq` runtime dependency on the plugin path. They are contained by the backend's realpath sandbox and are tracked in #36 for manual confirmation.

Refs #36

https://claude.ai/code/session_01N2jmtm2VxbSDTd4xmVYqTU

---
_Generated by [Claude Code](https://claude.ai/code/session_01N2jmtm2VxbSDTd4xmVYqTU)_