### PR TITLE
fix(security): validate session_id to prevent path traversal in /session/handoff

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -45,6 +45,7 @@ from session_manager import (
     set_session_name,
     shutdown_all,
 )
+from tmux_runner import validate_session_id
 from tools import TOOL_DEFINITIONS, dispatch_tool
 
 load_dotenv()
@@ -407,6 +408,13 @@ async def handoff_session(req: HandoffRequest) -> dict[str, Any]:
     sid = (req.session_id or "").strip()
     if not sid:
         raise HTTPException(status_code=400, detail="session_id is required")
+    # session_id becomes a directory name under the session store; reject anything
+    # that isn't a safe single path component so it can't traverse out (see
+    # tmux_runner.validate_session_id).
+    try:
+        sid = validate_session_id(sid)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
 
     # Already a live vc_ session (seamless launcher path) — nothing to reopen.
     pane = cli_pane_for(sid)

--- a/backend/main.py
+++ b/backend/main.py
@@ -408,9 +408,8 @@ async def handoff_session(req: HandoffRequest) -> dict[str, Any]:
     sid = (req.session_id or "").strip()
     if not sid:
         raise HTTPException(status_code=400, detail="session_id is required")
-    # session_id becomes a directory name under the session store; reject anything
-    # that isn't a safe single path component so it can't traverse out (see
-    # tmux_runner.validate_session_id).
+    # session_id becomes a directory name under the session store; reject path
+    # traversal before it is used (see tmux_runner.validate_session_id).
     try:
         sid = validate_session_id(sid)
     except ValueError as exc:

--- a/backend/tmux_runner.py
+++ b/backend/tmux_runner.py
@@ -124,18 +124,14 @@ CTRL_ROOT = config.SESSION_STORE_DIR  # set via VC_SESSION_STORE; defaults insid
 HOOK_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "tmux_hooks")
 ENABLE_CHROME = os.getenv("CLAUDE_CLI_CHROME", "1") != "0"
 
-# A session id becomes a directory name under CTRL_ROOT (see _TmuxSession.ctrl),
-# so it must be a single safe path component. Without this, a caller-supplied id
-# like "../../foo" on the handoff/resume path would traverse outside the session
-# store and let os.makedirs/_write_* create or overwrite files there. Real Claude
-# session ids are UUIDs; fresh sessions use uuid4(), so this only constrains the
-# externally supplied resume/handoff id.
+# A session id becomes a directory name under CTRL_ROOT, so it must be a single
+# safe path component; otherwise a caller-supplied id like "../../foo" would
+# traverse out of the session store. Real session ids are UUIDs.
 _SESSION_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$")
 
 
 def validate_session_id(session_id: str) -> str:
-    """Return the trimmed id if it is a safe single path component, else raise
-    ValueError. Rejects ids containing '/', '\\', '.', or a leading non-alnum."""
+    """Return the trimmed id if it is a safe single path component, else raise ValueError."""
     sid = (session_id or "").strip()
     if not _SESSION_ID_RE.match(sid):
         raise ValueError(f"invalid session id (expected a UUID-like token): {session_id!r}")
@@ -230,10 +226,9 @@ class TmuxClaudeRunner(ClaudeRunner):
         """Create the detached tmux pane running `claude` (with our hooks wired via
         --settings) and start tracking it. `claude_id_arg` is either
         `--session-id <new uuid>` (fresh start) or `--resume <existing id>`."""
-        # Defense in depth: the control dir is derived from the (already validated)
-        # session id, but assert containment before any makedirs/write so a path
-        # can never escape the session store even if a future caller skips
-        # validate_session_id.
+        # Defense in depth: assert containment before any makedirs/write so the
+        # control dir can never escape the session store, even if a future caller
+        # reaches _spawn without going through validate_session_id.
         ctrl_real = os.path.realpath(s.ctrl)
         root_real = os.path.realpath(CTRL_ROOT)
         if ctrl_real != root_real and not ctrl_real.startswith(root_real + os.sep):

--- a/backend/tmux_runner.py
+++ b/backend/tmux_runner.py
@@ -124,6 +124,23 @@ CTRL_ROOT = config.SESSION_STORE_DIR  # set via VC_SESSION_STORE; defaults insid
 HOOK_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "tmux_hooks")
 ENABLE_CHROME = os.getenv("CLAUDE_CLI_CHROME", "1") != "0"
 
+# A session id becomes a directory name under CTRL_ROOT (see _TmuxSession.ctrl),
+# so it must be a single safe path component. Without this, a caller-supplied id
+# like "../../foo" on the handoff/resume path would traverse outside the session
+# store and let os.makedirs/_write_* create or overwrite files there. Real Claude
+# session ids are UUIDs; fresh sessions use uuid4(), so this only constrains the
+# externally supplied resume/handoff id.
+_SESSION_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$")
+
+
+def validate_session_id(session_id: str) -> str:
+    """Return the trimmed id if it is a safe single path component, else raise
+    ValueError. Rejects ids containing '/', '\\', '.', or a leading non-alnum."""
+    sid = (session_id or "").strip()
+    if not _SESSION_ID_RE.match(sid):
+        raise ValueError(f"invalid session id (expected a UUID-like token): {session_id!r}")
+    return sid
+
 
 class _TmuxSession:
     def __init__(self, handle: str, cwd: str, model: str):
@@ -213,6 +230,14 @@ class TmuxClaudeRunner(ClaudeRunner):
         """Create the detached tmux pane running `claude` (with our hooks wired via
         --settings) and start tracking it. `claude_id_arg` is either
         `--session-id <new uuid>` (fresh start) or `--resume <existing id>`."""
+        # Defense in depth: the control dir is derived from the (already validated)
+        # session id, but assert containment before any makedirs/write so a path
+        # can never escape the session store even if a future caller skips
+        # validate_session_id.
+        ctrl_real = os.path.realpath(s.ctrl)
+        root_real = os.path.realpath(CTRL_ROOT)
+        if ctrl_real != root_real and not ctrl_real.startswith(root_real + os.sep):
+            raise ValueError("session control dir escapes the session store")
         os.makedirs(os.path.join(s.ctrl, "decisions"), exist_ok=True)
         self._write_settings(s)
         self._write_meta(s)
@@ -258,6 +283,7 @@ class TmuxClaudeRunner(ClaudeRunner):
         Reuses the real session id as our handle, so it slots into the same
         pane-naming / control-dir / rehydration machinery. Caller must ensure the
         original process has exited (single writer per session)."""
+        session_id = validate_session_id(session_id)
         if session_id in self._sessions:
             return session_id  # already adopted/running — no duplicate pane
         cwd = self._preflight(cwd)


### PR DESCRIPTION
## Daily security review fix — 2026-06-12

Fixes #40

### Finding addressed (HIGH) — Path traversal via unvalidated `session_id` in `/session/handoff`

The `session_id` field of a `/session/handoff` request was used as a directory name under the session store (`CTRL_ROOT`) without any path-component validation. It flowed:

`HandoffRequest.session_id` → `handoff_session` (`main.py`) → `TmuxClaudeRunner.resume` → `_TmuxSession.ctrl = os.path.join(CTRL_ROOT, handle)` → `_spawn`'s `os.makedirs(...)` + `_write_settings`/`_write_meta`/`_write_mode`.

A value like `../../../../home/<user>/.claude` made `s.ctrl` resolve **outside** the session store, letting an authenticated (or, on a tokenless localhost install, any loopback) caller create directories and write/overwrite `settings.json` / `meta.json` / `mode` files anywhere the backend process can write — e.g. clobbering the user's global `~/.claude/settings.json`. The sibling `cwd` field was already containment-checked via `resolve_project_path`; `session_id` was not.

### Fix → finding mapping

| Change | Purpose |
|---|---|
| `backend/tmux_runner.py`: new `validate_session_id()` (regex `^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$`) | Rejects ids containing `/`, `\`, `.`, `..`, or a leading non-alphanumeric — UUIDs (the real id format) pass |
| `backend/main.py`: `handoff_session` calls `validate_session_id` and returns **400** on bad input | Clean rejection at the HTTP entry point |
| `backend/tmux_runner.py`: `resume()` validates `session_id` before use | Authoritative chokepoint, independent of caller |
| `backend/tmux_runner.py`: `_spawn` asserts `realpath(s.ctrl)` stays within `realpath(CTRL_ROOT)` before any `makedirs`/write | Defense-in-depth containment guarantee |

The `start()` path is unaffected — it already generates ids with `uuid4()`.

### Verification
- `python3 -m py_compile` passes on both files.
- Validator unit-checked: real UUIDs and `abc-123_DEF` accepted; `../../../../home/user/.claude`, `..`, `.hidden`, `a/b`, `a\b`, `foo/../bar`, and empty all rejected.
- `tests/test_pricing.py` passes (9/9); other backend test scripts skip cleanly due to optional deps absent in the review container (unrelated to this change).

Minimal, targeted change — no unrelated refactoring.

---
_Generated by the scheduled daily security review._

---
_Generated by [Claude Code](https://claude.ai/code/session_01QypcbVg1qBTqy3ErskPsJc)_