### PR TITLE
fix(security): escape shell-script values interpolated into JSON (L1/L2)

### DIFF
--- a/integrations/claude-code-plugin/bin/yapcode
+++ b/integrations/claude-code-plugin/bin/yapcode
@@ -19,8 +19,10 @@ CWD="${1:-$(pwd)}"
 hdr=(-H "Content-Type: application/json")
 [ -n "${YAPCODE_TOKEN:-}" ] && hdr+=(-H "X-VC-Token: ${YAPCODE_TOKEN}")
 
-resp="$(curl -fsS -X POST "$URL/tools/execute" "${hdr[@]}" \
-  -d "{\"name\":\"start_session\",\"arguments\":{\"project_path\":\"$CWD\"}}")" || {
+req="$(CWD="$CWD" python3 -c \
+  'import json,os; print(json.dumps({"name":"start_session","arguments":{"project_path":os.environ["CWD"]}}))')"
+
+resp="$(curl -fsS -X POST "$URL/tools/execute" "${hdr[@]}" -d "$req")" || {
   echo "yapcode: couldn't reach the backend at $URL (is it running?)" >&2
   exit 1
 }

--- a/integrations/claude-code-plugin/skills/voice-handoff/handoff.sh
+++ b/integrations/claude-code-plugin/skills/voice-handoff/handoff.sh
@@ -21,7 +21,17 @@ if [ -n "${YAPCODE_TOKEN:-}" ]; then
   args+=(-H "X-VC-Token: ${YAPCODE_TOKEN}")
 fi
 
-payload="$(printf '{"session_id":"%s","cwd":"%s","tmux":"%s"}' "$sid" "$(pwd)" "${TMUX:-}")"
+# Escape a string for safe inclusion in a JSON value (backslash and quote are the
+# only characters a session-id/path/$TMUX realistically contains that break JSON).
+json_escape() {
+  local s=$1
+  s=${s//\\/\\\\}
+  s=${s//\"/\\\"}
+  printf '%s' "$s"
+}
+
+payload="$(printf '{"session_id":"%s","cwd":"%s","tmux":"%s"}' \
+  "$(json_escape "$sid")" "$(json_escape "$(pwd)")" "$(json_escape "${TMUX:-}")")"
 
 curl "${args[@]}" -d "$payload" ||
   printf '{"error":"could not reach yapcode — is the backend running at %s?"}\n' "$url"


### PR DESCRIPTION
## Daily security review fix — resolves L1/L2 from #36

The two plugin shell scripts built JSON request bodies by **raw string interpolation**, so any value containing `"` or `\` produced malformed or injected JSON.

### Findings addressed (LOW)

| | File | Field(s) | Before |
|---|---|---|---|
| **L1** | `integrations/claude-code-plugin/bin/yapcode` | `project_path` (`$CWD`) | `-d "{\"name\":\"start_session\",\"arguments\":{\"project_path\":\"$CWD\"}}"` |
| **L2** | `integrations/claude-code-plugin/skills/voice-handoff/handoff.sh` | `session_id`, `cwd`, `tmux` | `printf '{"session_id":"%s",...}' "$sid" "$(pwd)" "${TMUX:-}"` |

### Severity / scope

These are **robustness/hygiene defects, not a sandbox break**: inputs are local and user-controlled, and the backend's `ALLOWED_PROJECT_ROOTS` realpath sandbox blocks path escape. The realistic impact is a directory path containing a `"` or `\` (both legal) silently breaking the launcher / handoff with malformed JSON.

### Fix

- **L1** — build the request body with `python3 -c json.dumps`. The script already shells out to `python3` to parse the response, so **no new dependency**.
- **L2** — add a dependency-free bash `json_escape` (doubles `\`, escapes `"`) and route `session_id` / `cwd` / `tmux` through it.

> Deliberately avoided the review's suggested `jq` fix — `jq` isn't universally installed, and breaking the launcher for users without it would be worse than the bug.

### Interaction with #41

#41 added server-side `validate_session_id()` on `/session/handoff`. That **complements** L2 (defense in depth) rather than making it redundant: `cwd` and `tmux` are still unvalidated at JSON-parse time, so escaping them is the primary robustness value; escaping `session_id` additionally lets a bad value reach the validator for a clean 400 instead of a generic JSON-parse error.

### Testing

- `bash -n` passes on both scripts.
- Functional check: both JSON builders produce valid, correctly-escaped JSON for hostile inputs containing `"` and `\`, with the exact expected request shape.

Closes #36 (M1 was already fixed in #37; L1/L2 were the only remaining items).

🤖 Generated with [Claude Code](https://claude.com/claude-code)