### PR TITLE
Show session name in live Claude CLI heading

### DIFF
--- a/frontend/components/VoiceAgent.tsx
+++ b/frontend/components/VoiceAgent.tsx
@@ -1881,6 +1881,8 @@ export default function VoiceAgent() {
         const liveSess = sessions.find((x) => x.handle === liveSession);
         const liveTmuxCmd =
           liveSess?.backend === "cli" ? `tmux attach -t vc_${liveSess.handle.slice(0, 8)}` : null;
+        const liveName =
+          liveSess?.name || liveSess?.cwd.split("/").pop() || liveSess?.handle.slice(0, 8) || "Live Claude CLI";
         return (
           <div
             className="tx-overlay"
@@ -1891,7 +1893,7 @@ export default function VoiceAgent() {
           >
             <div className="tx-modal" onClick={(e) => e.stopPropagation()}>
               <div className="tx-modal-head">
-                <span>Live Claude CLI</span>
+                <span>{liveName}</span>
                 <div className="tx-head-actions">
                   {liveTmuxCmd && (
                     <button


### PR DESCRIPTION
## Summary
The live Claude CLI full-screen view always showed the static heading **"Live Claude CLI"**. This changes the heading to display the current session's human-readable name instead.

The name resolution follows the convention already used in the session list (`VoiceAgent.tsx`):
- session `name` if set, else
- the cwd basename, else
- the short handle, else
- `"Live Claude CLI"` as a final fallback.

## Changes
- `frontend/components/VoiceAgent.tsx`: derive `liveName` from `liveSess` and render it in the `tx-modal-head` heading.

## Test plan
- Open a session, give it a name, and open the live full-screen view → heading shows the name.
- Open the live view for an unnamed session → heading shows the cwd basename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)