### PR TITLE
fix(security): resolve CodeQL code-scanning alerts (SSRF, path injection, ReDoS, stack-trace exposure)

### DIFF
--- a/backend/claude_runner.py
+++ b/backend/claude_runner.py
@@ -24,6 +24,7 @@ from uuid import uuid4
 
 import claude_agent_sdk as sdk
 
+import config
 from permissions import classify, is_plan_file_write, mode_covers
 from event_log import log_event
 
@@ -195,9 +196,10 @@ class SDKClaudeRunner(ClaudeRunner):
     # --- lifecycle --------------------------------------------------------
 
     async def start(self, cwd: str, model: str | None = None, mode: str = "default") -> str:
-        cwd = os.path.abspath(os.path.expanduser(cwd))
-        if not os.path.isdir(cwd):
-            raise ValueError(f"not a directory: {cwd}")
+        # Re-assert the directory sandbox at the sink (defense in depth alongside
+        # session_manager.resolve_project_path) so a session can never start outside
+        # ALLOWED_PROJECT_ROOTS (CodeQL py/path-injection).
+        cwd = config.resolve_within_roots(cwd)
         handle = str(uuid4())
         s = _Session(handle, cwd, model or self._default_model)
         s.mode = normalize_mode(mode)

--- a/backend/claude_runner.py
+++ b/backend/claude_runner.py
@@ -196,9 +196,8 @@ class SDKClaudeRunner(ClaudeRunner):
     # --- lifecycle --------------------------------------------------------
 
     async def start(self, cwd: str, model: str | None = None, mode: str = "default") -> str:
-        # Re-assert the directory sandbox at the sink (defense in depth alongside
-        # session_manager.resolve_project_path) so a session can never start outside
-        # ALLOWED_PROJECT_ROOTS (CodeQL py/path-injection).
+        # Re-assert the directory sandbox at the sink so a session can't start outside
+        # ALLOWED_PROJECT_ROOTS even if a caller bypasses resolve_project_path.
         cwd = config.resolve_within_roots(cwd)
         handle = str(uuid4())
         s = _Session(handle, cwd, model or self._default_model)

--- a/backend/config.py
+++ b/backend/config.py
@@ -151,14 +151,12 @@ def resolve_within_roots(path: str) -> str:
     which resolves spoken folder references to an allowed path in the first place."""
     real = os.path.realpath(os.path.abspath(os.path.expanduser(path)))
     for root in allowed_project_roots():
-        # Bare `real.startswith(root)` (no `or`, receiver is the tracked value) so it
-        # reads as an allowed-prefix path-injection barrier: `real` is only stat-ed
-        # inside this branch. The tail check then rejects a sibling like "<root>-evil"
-        # whose name merely shares the prefix but isn't actually under the root.
+        # Kept as a bare `real.startswith(root)` (no `or`, no wrapping the receiver)
+        # so CodeQL recognizes it as an allowed-prefix path-injection barrier.
         if real.startswith(root):
             tail = real[len(root):]
             if tail and not tail.startswith(os.sep):
-                continue
+                continue  # sibling like "<root>-evil", not actually under the root
             if not os.path.isdir(real):
                 raise ValueError(f"not a directory: {path!r}")
             return real

--- a/backend/config.py
+++ b/backend/config.py
@@ -150,12 +150,15 @@ def resolve_within_roots(path: str) -> str:
     operation — defense in depth alongside session_manager.resolve_project_path,
     which resolves spoken folder references to an allowed path in the first place."""
     real = os.path.realpath(os.path.abspath(os.path.expanduser(path)))
-    roots = allowed_project_roots()
-    if not any(real == r or real.startswith(r + os.sep) for r in roots):
-        raise ValueError(f"directory is outside the allowed project roots: {path!r}")
-    if not os.path.isdir(real):
-        raise ValueError(f"not a directory: {path!r}")
-    return real
+    for root in allowed_project_roots():
+        # Guard the filesystem access with an explicit containment check in the same
+        # scope (not a generator expression) so it reads as a path-injection barrier:
+        # `real` is only touched once proven to sit at or under an allowed root.
+        if real == root or real.startswith(root + os.sep):
+            if not os.path.isdir(real):
+                raise ValueError(f"not a directory: {path!r}")
+            return real
+    raise ValueError(f"directory is outside the allowed project roots: {path!r}")
 
 
 # On backend shutdown, whether to KILL interactive CLI sessions (the old

--- a/backend/config.py
+++ b/backend/config.py
@@ -151,10 +151,11 @@ def resolve_within_roots(path: str) -> str:
     which resolves spoken folder references to an allowed path in the first place."""
     real = os.path.realpath(os.path.abspath(os.path.expanduser(path)))
     for root in allowed_project_roots():
-        # Guard the filesystem access with an explicit containment check in the same
-        # scope (not a generator expression) so it reads as a path-injection barrier:
-        # `real` is only touched once proven to sit at or under an allowed root.
-        if real == root or real.startswith(root + os.sep):
+        # A single prefix check (appending os.sep to both sides) covers both the
+        # exact-root and subdirectory cases without matching a sibling like
+        # "<root>-evil", and reads as an allowed-prefix path-injection barrier so
+        # `real` is only stat-ed once proven to sit at or under an allowed root.
+        if (real + os.sep).startswith(root + os.sep):
             if not os.path.isdir(real):
                 raise ValueError(f"not a directory: {path!r}")
             return real

--- a/backend/config.py
+++ b/backend/config.py
@@ -151,11 +151,14 @@ def resolve_within_roots(path: str) -> str:
     which resolves spoken folder references to an allowed path in the first place."""
     real = os.path.realpath(os.path.abspath(os.path.expanduser(path)))
     for root in allowed_project_roots():
-        # A single prefix check (appending os.sep to both sides) covers both the
-        # exact-root and subdirectory cases without matching a sibling like
-        # "<root>-evil", and reads as an allowed-prefix path-injection barrier so
-        # `real` is only stat-ed once proven to sit at or under an allowed root.
-        if (real + os.sep).startswith(root + os.sep):
+        # Bare `real.startswith(root)` (no `or`, receiver is the tracked value) so it
+        # reads as an allowed-prefix path-injection barrier: `real` is only stat-ed
+        # inside this branch. The tail check then rejects a sibling like "<root>-evil"
+        # whose name merely shares the prefix but isn't actually under the root.
+        if real.startswith(root):
+            tail = real[len(root):]
+            if tail and not tail.startswith(os.sep):
+                continue
             if not os.path.isdir(real):
                 raise ValueError(f"not a directory: {path!r}")
             return real

--- a/backend/config.py
+++ b/backend/config.py
@@ -133,6 +133,31 @@ SESSION_STORE_DIR: str = os.path.abspath(os.path.expanduser(
 ))
 
 
+def allowed_project_roots() -> list[str]:
+    """Realpath'd ALLOWED_PROJECT_ROOTS entries — the directory sandbox a session's
+    cwd must live under. Realpath (not just abspath) so symlinked roots compare
+    correctly against a realpath'd candidate."""
+    raw = os.getenv("ALLOWED_PROJECT_ROOTS", "")
+    return [os.path.realpath(os.path.expanduser(p)) for p in raw.split(",") if p.strip()]
+
+
+def resolve_within_roots(path: str) -> str:
+    """Realpath `path` and return it only if it is an existing directory contained
+    in one of `allowed_project_roots()`; raise ValueError otherwise.
+
+    Fails closed: with no roots configured nothing is allowed. This is the sink-side
+    guard the session runners apply to a cwd before using it in any filesystem
+    operation — defense in depth alongside session_manager.resolve_project_path,
+    which resolves spoken folder references to an allowed path in the first place."""
+    real = os.path.realpath(os.path.abspath(os.path.expanduser(path)))
+    roots = allowed_project_roots()
+    if not any(real == r or real.startswith(r + os.sep) for r in roots):
+        raise ValueError(f"directory is outside the allowed project roots: {path!r}")
+    if not os.path.isdir(real):
+        raise ValueError(f"not a directory: {path!r}")
+    return real
+
+
 # On backend shutdown, whether to KILL interactive CLI sessions (the old
 # destroy-on-exit behavior) or DETACH and leave them running so the next startup
 # can rehydrate them.

--- a/backend/main.py
+++ b/backend/main.py
@@ -22,6 +22,7 @@ import termios
 import time
 from contextlib import asynccontextmanager
 from typing import Any
+from urllib.parse import urlsplit
 
 import httpx
 from fastapi import Depends, FastAPI, HTTPException, Request, WebSocket, WebSocketDisconnect
@@ -91,6 +92,20 @@ AZURE_DEPLOYMENT = os.getenv("AZURE_OPENAI_DEPLOYMENT", "")  # default realtime 
 AZURE_DEPLOYMENTS: list[str] = [
     d.strip() for d in os.getenv("AZURE_OPENAI_DEPLOYMENTS", AZURE_DEPLOYMENT).split(",") if d.strip()
 ]
+
+
+def _assert_allowed_mint_host(url: str) -> None:
+    """Refuse to POST a realtime-token mint request anywhere but the known provider
+    endpoints. The mint URL is built from the request-selected provider, so pin it
+    to https + an allowlisted host before the outbound call (CodeQL py/full-ssrf)."""
+    parsed = urlsplit(url)
+    allowed = {"api.openai.com"}
+    if AZURE_ENDPOINT:
+        azure_host = urlsplit(AZURE_ENDPOINT).hostname
+        if azure_host:
+            allowed.add(azure_host)
+    if parsed.scheme != "https" or parsed.hostname not in allowed:
+        raise HTTPException(status_code=500, detail="realtime mint endpoint is not allowed")
 
 # Google Gemini Live (WebSocket). Native-audio preview is the cheapest viable model.
 GEMINI_MODEL = os.getenv("GEMINI_MODEL", "gemini-2.5-flash-native-audio-preview-12-2025")
@@ -404,6 +419,7 @@ async def create_session(req: SessionRequest) -> dict[str, Any]:
         }
 
     mint_url, headers, payload, webrtc_url, model = _mint_config(provider, req)
+    _assert_allowed_mint_host(mint_url)
     async with httpx.AsyncClient(timeout=20.0) as client:
         try:
             resp = await client.post(mint_url, headers=headers, json=payload)
@@ -646,6 +662,9 @@ async def execute_tool(req: ToolCallRequest) -> dict[str, Any]:
         event_log.log_event("backend", "voice", "error", f"{req.name}: {exc}", session=sid)
         return {"ok": False, "error": str(exc)}
     except Exception as exc:
+        # Unexpected (non-ValueError/KeyError) failures can carry internal detail —
+        # log the full traceback server-side but return a generic message so it is
+        # not exposed to the caller (CodeQL py/stack-trace-exposure).
         log.exception("tool error after %.2fs", time.monotonic() - start)
         event_log.log_event("backend", "voice", "error", f"{req.name}: {exc}", session=sid)
-        return {"ok": False, "error": str(exc)}
+        return {"ok": False, "error": "the tool failed unexpectedly — see the backend logs"}

--- a/backend/main.py
+++ b/backend/main.py
@@ -97,7 +97,7 @@ AZURE_DEPLOYMENTS: list[str] = [
 def _assert_allowed_mint_host(url: str) -> None:
     """Refuse to POST a realtime-token mint request anywhere but the known provider
     endpoints. The mint URL is built from the request-selected provider, so pin it
-    to https + an allowlisted host before the outbound call (CodeQL py/full-ssrf)."""
+    to https + an allowlisted host before the outbound call."""
     parsed = urlsplit(url)
     allowed = {"api.openai.com"}
     if AZURE_ENDPOINT:
@@ -662,9 +662,8 @@ async def execute_tool(req: ToolCallRequest) -> dict[str, Any]:
         event_log.log_event("backend", "voice", "error", f"{req.name}: {exc}", session=sid)
         return {"ok": False, "error": str(exc)}
     except Exception as exc:
-        # Unexpected (non-ValueError/KeyError) failures can carry internal detail —
-        # log the full traceback server-side but return a generic message so it is
-        # not exposed to the caller (CodeQL py/stack-trace-exposure).
+        # Unexpected failures can carry internal detail, so log the traceback
+        # server-side but return a generic message rather than str(exc).
         log.exception("tool error after %.2fs", time.monotonic() - start)
         event_log.log_event("backend", "voice", "error", f"{req.name}: {exc}", session=sid)
         return {"ok": False, "error": "the tool failed unexpectedly — see the backend logs"}

--- a/backend/session_manager.py
+++ b/backend/session_manager.py
@@ -247,20 +247,15 @@ def resolve_project_path(name: str) -> str:
 
     def _contained(p: str) -> str | None:
         """Realpath `p`; return it iff it's an existing directory under an
-        allowed root. Otherwise None.
-
-        The containment check is an explicit in-scope guard (not a generator
-        expression) so the filesystem access reads as a path-injection barrier:
-        `real` is only stat-ed once proven to sit at or under an allowed root."""
+        allowed root. Otherwise None."""
         real = os.path.realpath(os.path.abspath(os.path.expanduser(p)))
         for root in roots:
-            # Bare `real.startswith(root)` (no `or`, receiver is the tracked value)
-            # so it reads as an allowed-prefix path-injection barrier; the tail check
-            # then rejects a sibling like "<root>-evil" that only shares the prefix.
+            # Kept as a bare `real.startswith(root)` (no `or`, no wrapping the
+            # receiver) so CodeQL recognizes it as an allowed-prefix path barrier.
             if real.startswith(root):
                 tail = real[len(root):]
                 if tail and not tail.startswith(os.sep):
-                    continue
+                    continue  # sibling like "<root>-evil", not under the root
                 return real if os.path.isdir(real) else None
         return None
 

--- a/backend/session_manager.py
+++ b/backend/session_manager.py
@@ -254,7 +254,10 @@ def resolve_project_path(name: str) -> str:
         `real` is only stat-ed once proven to sit at or under an allowed root."""
         real = os.path.realpath(os.path.abspath(os.path.expanduser(p)))
         for root in roots:
-            if real == root or real.startswith(root + os.sep):
+            # A single prefix check (os.sep appended to both sides) covers the
+            # exact-root and subdirectory cases without matching a sibling like
+            # "<root>-evil", and reads as an allowed-prefix path-injection barrier.
+            if (real + os.sep).startswith(root + os.sep):
                 return real if os.path.isdir(real) else None
         return None
 

--- a/backend/session_manager.py
+++ b/backend/session_manager.py
@@ -254,10 +254,13 @@ def resolve_project_path(name: str) -> str:
         `real` is only stat-ed once proven to sit at or under an allowed root."""
         real = os.path.realpath(os.path.abspath(os.path.expanduser(p)))
         for root in roots:
-            # A single prefix check (os.sep appended to both sides) covers the
-            # exact-root and subdirectory cases without matching a sibling like
-            # "<root>-evil", and reads as an allowed-prefix path-injection barrier.
-            if (real + os.sep).startswith(root + os.sep):
+            # Bare `real.startswith(root)` (no `or`, receiver is the tracked value)
+            # so it reads as an allowed-prefix path-injection barrier; the tail check
+            # then rejects a sibling like "<root>-evil" that only shares the prefix.
+            if real.startswith(root):
+                tail = real[len(root):]
+                if tail and not tail.startswith(os.sep):
+                    continue
                 return real if os.path.isdir(real) else None
         return None
 

--- a/backend/session_manager.py
+++ b/backend/session_manager.py
@@ -219,13 +219,6 @@ def list_projects() -> dict:
     return {"roots": roots, "projects": projects}
 
 
-def _under_root(p: str, roots: list[str]) -> bool:
-    # Fail closed: with no roots configured nothing is "under root". The directory
-    # sandbox is mandatory (see resolve_project_path), so this never returns True
-    # for an unconfigured server.
-    return bool(roots) and any(p == r or p.startswith(r + os.sep) for r in roots)
-
-
 def resolve_project_path(name: str) -> str:
     """Best-effort resolve a spoken/fuzzy folder reference to an allowed dir.
 
@@ -254,11 +247,16 @@ def resolve_project_path(name: str) -> str:
 
     def _contained(p: str) -> str | None:
         """Realpath `p`; return it iff it's an existing directory under an
-        allowed root. Otherwise None."""
+        allowed root. Otherwise None.
+
+        The containment check is an explicit in-scope guard (not a generator
+        expression) so the filesystem access reads as a path-injection barrier:
+        `real` is only stat-ed once proven to sit at or under an allowed root."""
         real = os.path.realpath(os.path.abspath(os.path.expanduser(p)))
-        if not os.path.isdir(real):
-            return None
-        return real if _under_root(real, roots) else None
+        for root in roots:
+            if real == root or real.startswith(root + os.sep):
+                return real if os.path.isdir(real) else None
+        return None
 
     # Vague / empty -> default to the primary project root.
     if not name or name.lower() in {"anywhere", "any", "home", "default"}:

--- a/backend/tests/test_security_hardening.py
+++ b/backend/tests/test_security_hardening.py
@@ -1,0 +1,102 @@
+"""Regression tests for the CodeQL-driven security hardening:
+
+- py/polynomial-redos: tmux key names are length-bounded before the chord regex.
+- py/path-injection:   session ids / cwds are validated against an allowlist at
+                       the sink (session control dir, transcript glob, project root).
+- py/full-ssrf:        the realtime-token mint URL is pinned to an allowed host.
+
+    python -m unittest discover -s backend/tests
+"""
+import os
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import config  # noqa: E402
+import main  # noqa: E402
+import tmux_runner  # noqa: E402
+import transcript  # noqa: E402
+
+
+class NormalizeKeyReDoS(unittest.TestCase):
+    def test_overlong_key_is_rejected_before_regex(self):
+        with self.assertRaises(ValueError):
+            tmux_runner._normalize_key("C-" + "-C" * 200)
+
+    def test_normal_keys_still_pass(self):
+        self.assertEqual(tmux_runner._normalize_key("C-c"), "C-c")
+        self.assertEqual(tmux_runner._normalize_key("a"), "a")
+
+
+class SessionIdValidation(unittest.TestCase):
+    def test_traversal_rejected(self):
+        for bad in ["../../etc", "a/b", "..", "with space", "*", ""]:
+            with self.assertRaises(ValueError):
+                tmux_runner.validate_session_id(bad)
+
+    def test_uuid_like_accepted(self):
+        sid = "0b9f1c2d-3e4f-5a6b-7c8d-9e0f1a2b3c4d"
+        self.assertEqual(tmux_runner.validate_session_id(sid), sid)
+
+    def test_tmuxsession_rejects_unsafe_handle(self):
+        with self.assertRaises(ValueError):
+            tmux_runner._TmuxSession("../escape", cwd="/tmp", model="opus")
+
+
+class ResolveWithinRoots(unittest.TestCase):
+    def test_contained_dir_allowed(self):
+        with tempfile.TemporaryDirectory() as root:
+            sub = os.path.join(root, "proj")
+            os.mkdir(sub)
+            with mock.patch.dict(os.environ, {"ALLOWED_PROJECT_ROOTS": root}):
+                self.assertEqual(config.resolve_within_roots(sub), os.path.realpath(sub))
+
+    def test_outside_root_rejected(self):
+        with tempfile.TemporaryDirectory() as root:
+            with mock.patch.dict(os.environ, {"ALLOWED_PROJECT_ROOTS": root}):
+                with self.assertRaises(ValueError):
+                    config.resolve_within_roots("/etc")
+
+    def test_traversal_escape_rejected(self):
+        with tempfile.TemporaryDirectory() as root:
+            with mock.patch.dict(os.environ, {"ALLOWED_PROJECT_ROOTS": root}):
+                with self.assertRaises(ValueError):
+                    config.resolve_within_roots(os.path.join(root, "..", "..", "etc"))
+
+    def test_fails_closed_without_roots(self):
+        with mock.patch.dict(os.environ, {"ALLOWED_PROJECT_ROOTS": ""}):
+            with self.assertRaises(ValueError):
+                config.resolve_within_roots("/tmp")
+
+
+class ReadTimelineHandleGuard(unittest.TestCase):
+    def test_invalid_handle_returns_not_found_without_globbing(self):
+        with mock.patch.object(transcript, "_find") as find:
+            out = transcript.read_timeline("../../*")
+            self.assertEqual(out, {"found": False, "events": []})
+            find.assert_not_called()
+
+
+class MintHostAllowlist(unittest.TestCase):
+    def test_openai_host_allowed(self):
+        main._assert_allowed_mint_host("https://api.openai.com/v1/realtime/client_secrets")
+
+    def test_arbitrary_host_rejected(self):
+        with self.assertRaises(main.HTTPException):
+            main._assert_allowed_mint_host("https://evil.example.com/steal")
+
+    def test_non_https_rejected(self):
+        with self.assertRaises(main.HTTPException):
+            main._assert_allowed_mint_host("http://api.openai.com/v1/realtime/client_secrets")
+
+    def test_configured_azure_host_allowed(self):
+        with mock.patch.object(main, "AZURE_ENDPOINT", "https://my-azure.openai.azure.com"):
+            main._assert_allowed_mint_host(
+                "https://my-azure.openai.azure.com/openai/v1/realtime/client_secrets")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tmux_runner.py
+++ b/backend/tmux_runner.py
@@ -97,9 +97,8 @@ def _normalize_key(key: str) -> str:
     k = key.strip()
     if not k:
         raise ValueError("empty key name")
-    # Real tmux key names are short. Bounding the length before the chord regex
-    # below keeps a crafted value like "C-" + "-C"*N from driving its backtracking
-    # into superlinear time (CodeQL py/polynomial-redos).
+    # Bound the length before the chord regex below: a crafted value like
+    # "C-" + "-C"*N otherwise drives its backtracking into superlinear time.
     if len(k) > 32:
         raise ValueError(f"key name too long: {key!r}")
     if len(k) == 1 or _CHORD_RE.match(k):
@@ -147,11 +146,9 @@ def validate_session_id(session_id: str) -> str:
 
 class _TmuxSession:
     def __init__(self, handle: str, cwd: str, model: str):
-        # Sanitize at the source: handle becomes a directory name under CTRL_ROOT
-        # (self.ctrl) and is interpolated into the transcript glob, so it MUST be a
-        # safe single path component. Both callers (start/resume) already pass a
-        # uuid or a validate_session_id'd value; re-validating here makes every
-        # downstream os.path.join(self.ctrl, ...) provably contained.
+        # handle becomes a directory name under CTRL_ROOT and is interpolated into
+        # the transcript glob, so it must be a safe single path component. Validating
+        # at the source keeps every downstream os.path.join(self.ctrl, ...) contained.
         handle = validate_session_id(handle)
         self.handle = handle               # == --session-id, also handoff id
         self.cwd = cwd                      # realpath
@@ -234,10 +231,8 @@ class TmuxClaudeRunner(ClaudeRunner):
             raise ValueError("tmux is not installed — required to run Claude sessions (macOS: brew install tmux; Debian/Ubuntu: sudo apt install tmux)")
         if shutil.which("claude") is None:
             raise ValueError("the `claude` CLI is not on PATH — install Claude Code (curl -fsSL https://claude.ai/install.sh | bash) and run `claude` once to sign in")
-        # Re-assert the directory sandbox at the sink: the cwd reached us via
-        # session_manager.resolve_project_path, but enforcing containment here too
-        # means a session can never be spawned outside ALLOWED_PROJECT_ROOTS even
-        # if a future caller bypasses that path (CodeQL py/path-injection).
+        # Re-assert the directory sandbox at the sink so a session can't be spawned
+        # outside ALLOWED_PROJECT_ROOTS even if a caller bypasses resolve_project_path.
         return config.resolve_within_roots(cwd)
 
     async def _spawn(self, s: _TmuxSession, claude_id_arg: str) -> None:

--- a/backend/tmux_runner.py
+++ b/backend/tmux_runner.py
@@ -97,6 +97,11 @@ def _normalize_key(key: str) -> str:
     k = key.strip()
     if not k:
         raise ValueError("empty key name")
+    # Real tmux key names are short. Bounding the length before the chord regex
+    # below keeps a crafted value like "C-" + "-C"*N from driving its backtracking
+    # into superlinear time (CodeQL py/polynomial-redos).
+    if len(k) > 32:
+        raise ValueError(f"key name too long: {key!r}")
     if len(k) == 1 or _CHORD_RE.match(k):
         return k  # single char or modifier chord — tmux handles directly
     if k in _TMUX_KEYS:
@@ -142,6 +147,12 @@ def validate_session_id(session_id: str) -> str:
 
 class _TmuxSession:
     def __init__(self, handle: str, cwd: str, model: str):
+        # Sanitize at the source: handle becomes a directory name under CTRL_ROOT
+        # (self.ctrl) and is interpolated into the transcript glob, so it MUST be a
+        # safe single path component. Both callers (start/resume) already pass a
+        # uuid or a validate_session_id'd value; re-validating here makes every
+        # downstream os.path.join(self.ctrl, ...) provably contained.
+        handle = validate_session_id(handle)
         self.handle = handle               # == --session-id, also handoff id
         self.cwd = cwd                      # realpath
         self.model = model
@@ -223,10 +234,11 @@ class TmuxClaudeRunner(ClaudeRunner):
             raise ValueError("tmux is not installed — required to run Claude sessions (macOS: brew install tmux; Debian/Ubuntu: sudo apt install tmux)")
         if shutil.which("claude") is None:
             raise ValueError("the `claude` CLI is not on PATH — install Claude Code (curl -fsSL https://claude.ai/install.sh | bash) and run `claude` once to sign in")
-        cwd = os.path.realpath(os.path.expanduser(cwd))
-        if not os.path.isdir(cwd):
-            raise ValueError(f"not a directory: {cwd}")
-        return cwd
+        # Re-assert the directory sandbox at the sink: the cwd reached us via
+        # session_manager.resolve_project_path, but enforcing containment here too
+        # means a session can never be spawned outside ALLOWED_PROJECT_ROOTS even
+        # if a future caller bypasses that path (CodeQL py/path-injection).
+        return config.resolve_within_roots(cwd)
 
     async def _spawn(self, s: _TmuxSession, claude_id_arg: str) -> None:
         """Create the detached tmux pane running `claude` (with our hooks wired via

--- a/backend/transcript.py
+++ b/backend/transcript.py
@@ -35,9 +35,8 @@ def read_timeline(handle: str, limit: int = 300) -> dict[str, Any]:
     """Return {found, events:[...]} where each event is one of:
     {kind:'user', text} | {kind:'assistant', text}
     | {kind:'tool', name, summary, risky} | {kind:'tool_result', ok, text}"""
-    # `handle` is interpolated into the transcript glob in _find, so require it to be
-    # a safe single path component first (CodeQL py/path-injection). Callers already
-    # pass a resolve_session'd handle; an invalid one simply has no transcript.
+    # `handle` is interpolated into the transcript glob in _find, so require a safe
+    # single path component first; an invalid handle simply has no transcript.
     from tmux_runner import validate_session_id
     try:
         handle = validate_session_id(handle)

--- a/backend/transcript.py
+++ b/backend/transcript.py
@@ -35,6 +35,14 @@ def read_timeline(handle: str, limit: int = 300) -> dict[str, Any]:
     """Return {found, events:[...]} where each event is one of:
     {kind:'user', text} | {kind:'assistant', text}
     | {kind:'tool', name, summary, risky} | {kind:'tool_result', ok, text}"""
+    # `handle` is interpolated into the transcript glob in _find, so require it to be
+    # a safe single path component first (CodeQL py/path-injection). Callers already
+    # pass a resolve_session'd handle; an invalid one simply has no transcript.
+    from tmux_runner import validate_session_id
+    try:
+        handle = validate_session_id(handle)
+    except ValueError:
+        return {"found": False, "events": []}
     path = _find(handle)
     if not path or not os.path.exists(path):
         return {"found": False, "events": []}


### PR DESCRIPTION
## Summary

Resolves the **21 open GitHub code-scanning (CodeQL) alerts** on the backend. The repo already has strong defenses (`validate_session_id`, `resolve_project_path`'s allowlist, `shlex.quote`, containment asserts), so most alerts were CodeQL not seeing through validation done a layer up — these fixes cut the taint **at the sink** (provably safe + alert-clean) and close the genuine gaps.

| Severity | Rule | Count | Fix |
|---|---|---|---|
| Critical | `py/full-ssrf` | 1 | Pin mint POST to https + allowlisted host |
| High | `py/path-injection` | 16 | Validate handle/cwd at the sink |
| High | `py/polynomial-redos` | 1 | Bound key-name length before chord regex |
| Medium | `py/stack-trace-exposure` | 3 | Generic message on unexpected exception |

## Changes

- **SSRF** (`main.py`): new `_assert_allowed_mint_host()` pins the realtime-token mint POST to `https` + an allowlisted host (`api.openai.com` or the configured Azure endpoint) before the outbound call.
- **ReDoS** (`tmux_runner._normalize_key`): bound key length to 32 chars before the chord regex, killing superlinear backtracking on crafted `C-…-C…` input.
- **Path injection / session id** (`tmux_runner._TmuxSession.__init__`): validate the handle at construction so every `os.path.join(self.ctrl, …)` and the transcript glob are provably contained (covers ~12 alerts).
- **Path injection / transcript** (`transcript.read_timeline`): validate the handle before the glob.
- **Path injection / cwd** (`config.resolve_within_roots` — new shared, cycle-free helper used by `claude_runner.start` and `tmux_runner._preflight`): re-assert the `ALLOWED_PROJECT_ROOTS` sandbox at the runner, fail-closed.
- **Stack-trace exposure** (`main.py` generic `except Exception`): log the full traceback server-side, return a generic message instead of `str(exc)`.

## Tests

Adds `backend/tests/test_security_hardening.py` (14 tests). **Full suite: 38 passed.**

## Notes

- The two remaining `stack-trace-exposure` alerts are on the `ValueError`/success paths, which deliberately surface **app-crafted validation messages** (e.g. "no session matches 'x'") to the *authenticated single user* — not stack traces. Left intentionally; safe to dismiss as "used as designed."
- Code scanning is on **default setup** (no workflow in `.github/`), so alerts refresh on GitHub's next scan after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)