### PR TITLE
security: validate tool_use_id path component; drop --reload in network mode

### DIFF
--- a/backend/run-network.sh
+++ b/backend/run-network.sh
@@ -37,16 +37,16 @@ if [ -z "${VC_AUTH_TOKEN:-}" ]; then
   exit 1
 fi
 
-# --reload: hot-reload on backend code changes. With detach-on-shutdown the
-# reload preserves running CLI sessions (they're rehydrated on the restart).
-# --reload-dir . limits the watcher to backend/ so the session store under the
-# project root (rapidly-written events.jsonl) never triggers reloads.
+# NOTE: unlike the localhost run.sh, this network-exposed (0.0.0.0) mode does
+# NOT enable uvicorn --reload. The autoreloader's file-watcher and child-process
+# supervisor are extra attack surface that shouldn't run on a LAN-reachable
+# service (and any writable-code scenario would become reload-triggered RCE).
 # --timeout-graceful-shutdown: long-lived SSE/poll/terminal-WS connections
-# never drain on their own, so a reload (or stop) would hang on "Waiting for
-# connections to close". 3s lets an in-flight request finish, then force-closes.
+# never drain on their own, so a stop would hang on "Waiting for connections to
+# close". 3s lets an in-flight request finish, then force-closes.
 exec .venv/bin/python -m uvicorn main:app \
   --host 0.0.0.0 --port 8000 \
   --ssl-keyfile ../frontend/.certs/dev-key.pem \
   --ssl-certfile ../frontend/.certs/dev-cert.pem \
   --log-level info \
-  --reload --reload-dir . --timeout-graceful-shutdown 3
+  --timeout-graceful-shutdown 3

--- a/backend/tmux_hooks/_common.py
+++ b/backend/tmux_hooks/_common.py
@@ -12,10 +12,24 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import sys
 import time
 
 CTRL = os.environ.get("VC_CTRL", "")
+
+# tool_use_id is interpolated into a decisions/<id>.json path that reaches
+# open()/os.remove()/os.replace(). It is normally a CLI-minted `toolu_*` token,
+# but — like every other externally-derived path component in this codebase
+# (session_id/handle, validated via tmux_runner._SESSION_ID_RE) — it must be
+# validated so it can never escape the decisions/ dir via traversal or
+# separators. Same charset/length bound as validate_session_id.
+_SAFE_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$")
+
+
+def safe_id(value: str) -> str:
+    """Return value if it is a safe single path component, else 'none'."""
+    return value if value and _SAFE_ID_RE.match(value) else "none"
 
 
 def read_input() -> dict:
@@ -38,7 +52,7 @@ def append_event(event: dict) -> None:
 
 
 def decision_path(tool_use_id: str) -> str:
-    return os.path.join(CTRL, "decisions", f"{tool_use_id or 'none'}.json")
+    return os.path.join(CTRL, "decisions", f"{safe_id(tool_use_id)}.json")
 
 
 def read_mode() -> str:

--- a/backend/tmux_runner.py
+++ b/backend/tmux_runner.py
@@ -671,7 +671,12 @@ class TmuxClaudeRunner(ClaudeRunner):
                               "tool_use_id": s.pending_tool_use_id})
             return None
         allow = decision == "allow"
-        path = os.path.join(s.ctrl, "decisions", f"{s.pending_tool_use_id or 'none'}.json")
+        # pending_tool_use_id is interpolated into a filesystem path, so validate
+        # it as a safe single path component (matches the hook's _common.safe_id);
+        # fall back to 'none' rather than letting a malformed id escape decisions/.
+        tu_id = (s.pending_tool_use_id or "").strip()
+        decision_id = tu_id if _SESSION_ID_RE.match(tu_id) else "none"
+        path = os.path.join(s.ctrl, "decisions", f"{decision_id}.json")
         tmp = path + ".tmp"
         with open(tmp, "w") as f:
             json.dump({"decision": decision,


### PR DESCRIPTION
Fixes the auto-fixable findings from the daily security review (#49).

## Fixes

### L1 — `tool_use_id` validated before use as a filesystem path component
`tool_use_id` is interpolated into `decisions/<id>.json` and reaches `open()`, `os.remove()`, and `os.replace()`, but — unlike `session_id`/`handle` (validated via `_SESSION_ID_RE`) — it had no validation, so a traversal value could escape the `decisions/` dir.
- `backend/tmux_hooks/_common.py` — add `safe_id()` (same charset/length bound as `validate_session_id`) and use it in `decision_path()`.
- `backend/tmux_runner.py` — apply the matching guard on the runner's write side (`os.replace` path).

### L2 — `--reload` removed from the network-exposed run script
- `backend/run-network.sh` — the `0.0.0.0`-bound mode no longer enables uvicorn `--reload`; the autoreloader's file-watcher/child-process supervisor is needless attack surface on a LAN-reachable service (and turns any writable-code scenario into reload-triggered RCE). The localhost `run.sh` is unchanged.

## Left for manual attention (NOT in this PR)

### M1 (Medium) — DNS-rebinding can reach the command-executing API in the default tokenless mode
There is no `Host`-header validation anywhere, so a DNS-rebinding attack (and any co-resident localhost web app) can satisfy both the proxy's same-origin check and the backend's loopback trust. The fix — a `Host` allowlist via Starlette `TrustedHostMiddleware` and/or a check in `blockCrossSite()` — needs design care so legitimate LAN access in network mode (`192.168.x.x` / hostname) keeps working (suggest a `VC_ALLOWED_HOSTS` env knob). Deliberately left out so it can be reviewed deliberately.

## Verification
- `python -m py_compile` passes on both edited Python files.
- `bash -n` passes on `run-network.sh`.
- (pytest is not installed in the review environment, so the suite wasn't run here.)

Fixes #49 (L1, L2). M1 tracked in #49 for manual follow-up.

---
_Generated by [Claude Code](https://claude.ai/code/session_0186kFkxiLCUPEb8B7uSxNWs)_