### PR TITLE
README: prominent 'Watch the full demo' button under the preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ watch (and take over by keyboard) at any time.
 
 [![Watch the demo](https://img.youtube.com/vi/PFuo4jB9LQg/maxresdefault.jpg)](https://www.youtube.com/watch?v=PFuo4jB9LQg)
 
-**▶ [Watch the demo](https://www.youtube.com/watch?v=PFuo4jB9LQg)**
+[![Watch the full demo](docs/demo/watch-demo-button.svg)](https://www.youtube.com/watch?v=PFuo4jB9LQg)
+
+*5.5 minutes, unedited: a spoken sentence becomes a real command, running hands-free.*
 
 ### What it does
 

--- a/docs/demo/watch-demo-button.svg
+++ b/docs/demo/watch-demo-button.svg
@@ -1,0 +1,37 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="340" height="68" viewBox="0 0 340 68" role="img" aria-label="Watch the full demo">
+  <title>Watch the full demo</title>
+  <defs>
+    <linearGradient id="btnFace" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#FF3B30"/>
+      <stop offset="0.45" stop-color="#FF1A1A"/>
+      <stop offset="1" stop-color="#CC0000"/>
+    </linearGradient>
+    <linearGradient id="glossTop" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#FFFFFF" stop-opacity="0.28"/>
+      <stop offset="1" stop-color="#FFFFFF" stop-opacity="0"/>
+    </linearGradient>
+  </defs>
+
+  <!-- fake drop shadow: darker rect offset below the face -->
+  <rect x="4" y="7" width="332" height="57" rx="12" fill="#7A0000" opacity="0.55"/>
+  <rect x="4" y="5" width="332" height="57" rx="12" fill="#990000"/>
+
+  <!-- button face -->
+  <rect x="4" y="2" width="332" height="57" rx="12" fill="url(#btnFace)"/>
+
+  <!-- 1px inner top highlight line (gloss) -->
+  <rect x="6" y="4" width="328" height="2" rx="1" fill="#FFFFFF" opacity="0.45"/>
+  <!-- soft top gloss band -->
+  <rect x="8" y="4" width="324" height="26" rx="10" fill="url(#glossTop)"/>
+
+  <!-- play control: translucent white seat -->
+  <circle cx="42" cy="30.5" r="19" fill="#FFFFFF" opacity="0.16"/>
+  <circle cx="42" cy="30.5" r="19" fill="none" stroke="#FFFFFF" stroke-opacity="0.30" stroke-width="1.5"/>
+  <!-- solid white play triangle -->
+  <polygon points="35,20.5 35,40.5 53,30.5" fill="#FFFFFF"/>
+
+  <!-- label -->
+  <text x="203" y="38" text-anchor="middle" fill="#FFFFFF"
+        font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+        font-size="21" font-weight="700" letter-spacing="0.2">Watch the full demo</text>
+</svg>


### PR DESCRIPTION
You looked at the GIF hero and didn't want it, so this reworks the PR in the new direction: **keep the current YouTube thumbnail preview, and turn the plain text "Watch the demo" link under it into a real button that pulls clicks.**

### What changed
- **Kept** the YouTube thumbnail preview exactly as it was on `main` (the clickable `maxresdefault` image → the video).
- **Swapped** the plain `▶ Watch the demo` text link beneath it for a proper **button CTA**: red, rounded, a play ▶ glyph, bold "Watch the full demo" — links to the same video.
- **Dropped the GIF** and its asset entirely (no GIF, no mp4 — those still showed the home-network IP anyway).

### The button
It's a self-hosted SVG committed in the repo at `docs/demo/watch-demo-button.svg` (no external services, no tracking). I pushed it and **confirmed it renders on GitHub as a real image** — you can see it live in the README on this branch, it's not a broken image.

### Supporting line under the button
> *5.5 minutes, unedited: a spoken sentence becomes a real command, running hands-free.*

One alternative if you'd rather lower the entry cost:
> *Core loop lands in the first 60 seconds; the full run is 5.5 minutes.*

### Why this should convert better than the old text link
A button reads as a clear thing to click, and the line right under it tells a skimming developer exactly what they'll get and how little time it costs — a plain underlined link does neither.

### Files
- `README.md` — the two hero lines (thumbnail kept; text link → button + caption).
- `docs/demo/watch-demo-button.svg` — new button asset.

**Yours to review and merge — nothing is merged.**
