### PR TITLE
fix(security): fail closed on plan-approval declines; add frontend security headers

### DIFF
--- a/backend/claude_runner.py
+++ b/backend/claude_runner.py
@@ -589,6 +589,11 @@ class SDKClaudeRunner(ClaudeRunner):
         if tool_name == "ExitPlanMode":
             # Plan approval isn't binary: "auto"/"manual"/"proceed" leave plan
             # mode; anything else keeps planning and forwards the text as feedback.
+            # Fail closed: an explicit decline wins even when the phrase also
+            # contains an intent word — "do not proceed" / "don't approve" must
+            # NOT be read as approval just because they contain "proceed"/"approve".
+            if decide_permission(choice) == "deny":
+                return sdk.PermissionResultDeny(message=f"Keep planning: {choice}")
             if (decide_permission(choice) == "allow"
                     or any(w in c for w in ("auto", "manual", "proceed", "approve"))):
                 return sdk.PermissionResultAllow()

--- a/backend/tmux_runner.py
+++ b/backend/tmux_runner.py
@@ -690,6 +690,13 @@ class TmuxClaudeRunner(ClaudeRunner):
         (3. refine with Ultraplan on the web), or 'decline' (stay in plan mode,
         forward any feedback). Order matters: 'manually approve' contains an
         approve-word, so the more specific intents are checked first."""
+        # Fail closed: an explicit decline wins even when the phrase also contains
+        # an intent substring — "do not approve edits" / "don't switch to auto"
+        # must decline, not approve. decide_permission resolves genuine approvals
+        # ("manually approve edits") to "allow", so the intent paths below are
+        # unchanged; only true negations are short-circuited here.
+        if decide_permission(c) == "deny":
+            return "decline"
         if "manual" in c or "approve edit" in c or "each edit" in c or "review edit" in c:
             return "manual"
         if "ultraplan" in c or "on the web" in c or "refine on" in c:

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -6,6 +6,24 @@ const nextConfig = {
     // that bypass the same-origin proxy. Defaults to the standard backend port.
     BACKEND_PORT: process.env.BACKEND_PORT || "8000",
   },
+  // Security response headers for every route. This is an open same-origin proxy
+  // into a command-executing backend (and binds 0.0.0.0 in network mode), so deny
+  // framing (clickjacking of the voice-activate / on-screen controls), forbid
+  // MIME sniffing, and suppress referrer leakage. CSRF is separately handled by
+  // the Sec-Fetch-Site check in lib/proxyAuth.ts.
+  async headers() {
+    return [
+      {
+        source: "/:path*",
+        headers: [
+          { key: "X-Frame-Options", value: "DENY" },
+          { key: "Content-Security-Policy", value: "frame-ancestors 'none'" },
+          { key: "X-Content-Type-Options", value: "nosniff" },
+          { key: "Referrer-Policy", value: "no-referrer" },
+        ],
+      },
+    ];
+  },
   // Allow loading the dev server's /_next/* resources (JS chunks, HMR) when the
   // app is opened from another device on the LAN — otherwise Next 16 blocks them
   // as cross-origin and the client never hydrates (toggles/buttons do nothing).


### PR DESCRIPTION
Fixes the auto-fixable findings from the 2026-07-21 daily security review. Refs #52.

## Fixes (mapped to findings)

### M1 — `backend/claude_runner.py` (`SDKClaudeRunner._map_decision`, ExitPlanMode branch)
The branch approved the plan whenever the answer contained an intent word (`auto`/`manual`/`proceed`/`approve`), **even after `decide_permission` had already resolved it to `deny`**. So a decline such as `"do not proceed"` (which contains `"proceed"`) was inverted into `PermissionResultAllow()`, defeating the module's documented fail-closed contract.
**Fix:** short-circuit on an explicit `deny` before the intent-substring test.

### M2 — `backend/tmux_runner.py` (`_classify_plan_choice`)
The `manual`/`auto` intent substrings (`"manual"`, `"approve edit"`, `"each edit"`, `"review edit"`, `"auto"`) were tested **before** the decline branch, and that decline branch only caught negations at the *start* of the phrase. `"do not approve edits"` matched `"approve edit"` → `manual`, and a phrase like `"please don't switch to auto"` matched `"auto"` → escalated to auto-approve-everything mode.
**Fix:** evaluate an explicit decline (`decide_permission(c) == "deny"`) first.

### L1 — `frontend/next.config.mjs`
Added a `headers()` block applying `X-Frame-Options: DENY`, CSP `frame-ancestors 'none'`, `X-Content-Type-Options: nosniff`, and `Referrer-Policy: no-referrer` to all routes — clickjacking protection + defense-in-depth for the command-proxying UI (which binds `0.0.0.0` in network mode).

## Verification
`decide_permission` was checked in isolation to confirm the fixes preserve the happy paths:
- Declines that contain intent words → `deny` (now correctly short-circuited): `"do not proceed"`, `"don't approve"`, `"do not approve edits"`, `"please don't switch to auto"`.
- Genuine approvals → still approved: `"proceed"`, `"manually approve edits"`, `"auto"` (→ `None`, handled by the existing intent path), `"yes"`, `"approve"`.

No existing test references `_map_decision`, `_classify_plan_choice`, or `SAFE_TOOLS`, so behavior of the covered paths is unchanged. (The full pytest suite couldn't run in the review sandbox — `claude_agent_sdk` isn't installed there — so please let CI exercise it.)

## Left for manual attention (not in this PR)
- **M3 — `WebFetch`/`WebSearch` auto-approved as `safe`** (`backend/permissions.py:12-17`): a real prompt-injection exfiltration/SSRF path (unprompted `WebFetch` can carry local data to an arbitrary host), but removing it from `SAFE_TOOLS` is a deliberate product/UX tradeoff, so it's left for a maintainer decision.
- **Broad default Origin regex / no Host-header validation** — tracked in the still-open #49.
- **`NODE_TLS_REJECT_UNAUTHORIZED=0` in `dev:network`** — previously reported (#23/#36); loopback-capped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BJwDxJqz2ckLKHUTraLqLf

---
_Generated by [Claude Code](https://claude.ai/code/session_01BJwDxJqz2ckLKHUTraLqLf)_